### PR TITLE
fix(teams): allow all environments for team updates

### DIFF
--- a/internal/graph/teams.resolvers.go
+++ b/internal/graph/teams.resolvers.go
@@ -92,7 +92,7 @@ func (r *mutationResolver) UpdateTeam(ctx context.Context, slug slug.Slug, input
 	}
 
 	input = input.Sanitize()
-	err = input.Validate(r.clusters.GCPClusters())
+	err = input.Validate(r.clusters.Names())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously the check only allowed GCP clusters. This seems to stem from old Teams, so I'm unsure if the restriction is intended or not.

Console lists all environments for the team and also allows for updating Slack channels for individual environments, so if that's intended we should also allow this in api.