### PR TITLE
Utilization: When fetching specific data for team, group rows usable for

### DIFF
--- a/internal/database/gensql/mock_querier.go
+++ b/internal/database/gensql/mock_querier.go
@@ -6112,23 +6112,23 @@ func (_c *MockQuerier_SpecificResourceUtilizationForApp_Call) RunAndReturn(run f
 }
 
 // SpecificResourceUtilizationForTeam provides a mock function with given fields: ctx, arg
-func (_m *MockQuerier) SpecificResourceUtilizationForTeam(ctx context.Context, arg SpecificResourceUtilizationForTeamParams) (*SpecificResourceUtilizationForTeamRow, error) {
+func (_m *MockQuerier) SpecificResourceUtilizationForTeam(ctx context.Context, arg SpecificResourceUtilizationForTeamParams) ([]*SpecificResourceUtilizationForTeamRow, error) {
 	ret := _m.Called(ctx, arg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SpecificResourceUtilizationForTeam")
 	}
 
-	var r0 *SpecificResourceUtilizationForTeamRow
+	var r0 []*SpecificResourceUtilizationForTeamRow
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, SpecificResourceUtilizationForTeamParams) (*SpecificResourceUtilizationForTeamRow, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, SpecificResourceUtilizationForTeamParams) ([]*SpecificResourceUtilizationForTeamRow, error)); ok {
 		return rf(ctx, arg)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, SpecificResourceUtilizationForTeamParams) *SpecificResourceUtilizationForTeamRow); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, SpecificResourceUtilizationForTeamParams) []*SpecificResourceUtilizationForTeamRow); ok {
 		r0 = rf(ctx, arg)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*SpecificResourceUtilizationForTeamRow)
+			r0 = ret.Get(0).([]*SpecificResourceUtilizationForTeamRow)
 		}
 	}
 
@@ -6160,12 +6160,12 @@ func (_c *MockQuerier_SpecificResourceUtilizationForTeam_Call) Run(run func(ctx 
 	return _c
 }
 
-func (_c *MockQuerier_SpecificResourceUtilizationForTeam_Call) Return(_a0 *SpecificResourceUtilizationForTeamRow, _a1 error) *MockQuerier_SpecificResourceUtilizationForTeam_Call {
+func (_c *MockQuerier_SpecificResourceUtilizationForTeam_Call) Return(_a0 []*SpecificResourceUtilizationForTeamRow, _a1 error) *MockQuerier_SpecificResourceUtilizationForTeam_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockQuerier_SpecificResourceUtilizationForTeam_Call) RunAndReturn(run func(context.Context, SpecificResourceUtilizationForTeamParams) (*SpecificResourceUtilizationForTeamRow, error)) *MockQuerier_SpecificResourceUtilizationForTeam_Call {
+func (_c *MockQuerier_SpecificResourceUtilizationForTeam_Call) RunAndReturn(run func(context.Context, SpecificResourceUtilizationForTeamParams) ([]*SpecificResourceUtilizationForTeamRow, error)) *MockQuerier_SpecificResourceUtilizationForTeam_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/gensql/querier.go
+++ b/internal/database/gensql/querier.go
@@ -142,7 +142,7 @@ type Querier interface {
 	SpecificResourceUtilizationForApp(ctx context.Context, arg SpecificResourceUtilizationForAppParams) (*SpecificResourceUtilizationForAppRow, error)
 	// SpecificResourceUtilizationForTeam will return resource utilization for a team at a specific timestamp. Applications
 	// with a usage greater than request will be ignored.
-	SpecificResourceUtilizationForTeam(ctx context.Context, arg SpecificResourceUtilizationForTeamParams) (*SpecificResourceUtilizationForTeamRow, error)
+	SpecificResourceUtilizationForTeam(ctx context.Context, arg SpecificResourceUtilizationForTeamParams) ([]*SpecificResourceUtilizationForTeamRow, error)
 	TeamExists(ctx context.Context, argSlug slug.Slug) (bool, error)
 	UpdateTeam(ctx context.Context, arg UpdateTeamParams) (*Team, error)
 	UpdateTeamExternalReferences(ctx context.Context, arg UpdateTeamExternalReferencesParams) (*Team, error)

--- a/internal/database/gensql/resourceusage.sql.go
+++ b/internal/database/gensql/resourceusage.sql.go
@@ -339,20 +339,21 @@ func (q *Queries) SpecificResourceUtilizationForApp(ctx context.Context, arg Spe
 	return &i, err
 }
 
-const specificResourceUtilizationForTeam = `-- name: SpecificResourceUtilizationForTeam :one
+const specificResourceUtilizationForTeam = `-- name: SpecificResourceUtilizationForTeam :many
 SELECT
     SUM(usage)::double precision AS usage,
     SUM(request)::double precision AS request,
-    timestamp
+    timestamp,
+    request > usage as usable_for_cost
 FROM
     resource_utilization_metrics
 WHERE
     team_slug = $1
     AND resource_type = $2
     AND timestamp = $3
-    AND request > usage
 GROUP BY
-    timestamp
+    timestamp, usable_for_cost
+ORDER BY usable_for_cost DESC
 `
 
 type SpecificResourceUtilizationForTeamParams struct {
@@ -362,16 +363,35 @@ type SpecificResourceUtilizationForTeamParams struct {
 }
 
 type SpecificResourceUtilizationForTeamRow struct {
-	Usage     float64
-	Request   float64
-	Timestamp pgtype.Timestamptz
+	Usage         float64
+	Request       float64
+	Timestamp     pgtype.Timestamptz
+	UsableForCost bool
 }
 
 // SpecificResourceUtilizationForTeam will return resource utilization for a team at a specific timestamp. Applications
 // with a usage greater than request will be ignored.
-func (q *Queries) SpecificResourceUtilizationForTeam(ctx context.Context, arg SpecificResourceUtilizationForTeamParams) (*SpecificResourceUtilizationForTeamRow, error) {
-	row := q.db.QueryRow(ctx, specificResourceUtilizationForTeam, arg.TeamSlug, arg.ResourceType, arg.Timestamp)
-	var i SpecificResourceUtilizationForTeamRow
-	err := row.Scan(&i.Usage, &i.Request, &i.Timestamp)
-	return &i, err
+func (q *Queries) SpecificResourceUtilizationForTeam(ctx context.Context, arg SpecificResourceUtilizationForTeamParams) ([]*SpecificResourceUtilizationForTeamRow, error) {
+	rows, err := q.db.Query(ctx, specificResourceUtilizationForTeam, arg.TeamSlug, arg.ResourceType, arg.Timestamp)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*SpecificResourceUtilizationForTeamRow{}
+	for rows.Next() {
+		var i SpecificResourceUtilizationForTeamRow
+		if err := rows.Scan(
+			&i.Usage,
+			&i.Request,
+			&i.Timestamp,
+			&i.UsableForCost,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }

--- a/internal/database/mock_database.go
+++ b/internal/database/mock_database.go
@@ -5767,23 +5767,23 @@ func (_c *MockDatabase_SpecificResourceUtilizationForApp_Call) RunAndReturn(run 
 }
 
 // SpecificResourceUtilizationForTeam provides a mock function with given fields: ctx, teamSlug, resourceType, timestamp
-func (_m *MockDatabase) SpecificResourceUtilizationForTeam(ctx context.Context, teamSlug slug.Slug, resourceType gensql.ResourceType, timestamp pgtype.Timestamptz) (*gensql.SpecificResourceUtilizationForTeamRow, error) {
+func (_m *MockDatabase) SpecificResourceUtilizationForTeam(ctx context.Context, teamSlug slug.Slug, resourceType gensql.ResourceType, timestamp pgtype.Timestamptz) ([]*gensql.SpecificResourceUtilizationForTeamRow, error) {
 	ret := _m.Called(ctx, teamSlug, resourceType, timestamp)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SpecificResourceUtilizationForTeam")
 	}
 
-	var r0 *gensql.SpecificResourceUtilizationForTeamRow
+	var r0 []*gensql.SpecificResourceUtilizationForTeamRow
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, gensql.ResourceType, pgtype.Timestamptz) (*gensql.SpecificResourceUtilizationForTeamRow, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, gensql.ResourceType, pgtype.Timestamptz) ([]*gensql.SpecificResourceUtilizationForTeamRow, error)); ok {
 		return rf(ctx, teamSlug, resourceType, timestamp)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, gensql.ResourceType, pgtype.Timestamptz) *gensql.SpecificResourceUtilizationForTeamRow); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, slug.Slug, gensql.ResourceType, pgtype.Timestamptz) []*gensql.SpecificResourceUtilizationForTeamRow); ok {
 		r0 = rf(ctx, teamSlug, resourceType, timestamp)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*gensql.SpecificResourceUtilizationForTeamRow)
+			r0 = ret.Get(0).([]*gensql.SpecificResourceUtilizationForTeamRow)
 		}
 	}
 
@@ -5817,12 +5817,12 @@ func (_c *MockDatabase_SpecificResourceUtilizationForTeam_Call) Run(run func(ctx
 	return _c
 }
 
-func (_c *MockDatabase_SpecificResourceUtilizationForTeam_Call) Return(_a0 *gensql.SpecificResourceUtilizationForTeamRow, _a1 error) *MockDatabase_SpecificResourceUtilizationForTeam_Call {
+func (_c *MockDatabase_SpecificResourceUtilizationForTeam_Call) Return(_a0 []*gensql.SpecificResourceUtilizationForTeamRow, _a1 error) *MockDatabase_SpecificResourceUtilizationForTeam_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockDatabase_SpecificResourceUtilizationForTeam_Call) RunAndReturn(run func(context.Context, slug.Slug, gensql.ResourceType, pgtype.Timestamptz) (*gensql.SpecificResourceUtilizationForTeamRow, error)) *MockDatabase_SpecificResourceUtilizationForTeam_Call {
+func (_c *MockDatabase_SpecificResourceUtilizationForTeam_Call) RunAndReturn(run func(context.Context, slug.Slug, gensql.ResourceType, pgtype.Timestamptz) ([]*gensql.SpecificResourceUtilizationForTeamRow, error)) *MockDatabase_SpecificResourceUtilizationForTeam_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/internal/database/queries/resourceusage.sql
+++ b/internal/database/queries/resourceusage.sql
@@ -106,20 +106,21 @@ WHERE
 
 -- SpecificResourceUtilizationForTeam will return resource utilization for a team at a specific timestamp. Applications
 -- with a usage greater than request will be ignored.
--- name: SpecificResourceUtilizationForTeam :one
+-- name: SpecificResourceUtilizationForTeam :many
 SELECT
     SUM(usage)::double precision AS usage,
     SUM(request)::double precision AS request,
-    timestamp
+    timestamp,
+    request > usage as usable_for_cost
 FROM
     resource_utilization_metrics
 WHERE
     team_slug = @team_slug
     AND resource_type = @resource_type
     AND timestamp = @timestamp
-    AND request > usage
 GROUP BY
-    timestamp;
+    timestamp, usable_for_cost
+ORDER BY usable_for_cost DESC;
 
 -- AverageResourceUtilizationForTeam will return the average resource utilization for a team for a week.
 -- name: AverageResourceUtilizationForTeam :one

--- a/internal/database/resource_utilization.go
+++ b/internal/database/resource_utilization.go
@@ -18,7 +18,7 @@ type ResourceUtilizationRepo interface {
 	ResourceUtilizationRangeForTeam(ctx context.Context, teamSlug slug.Slug) (*gensql.ResourceUtilizationRangeForTeamRow, error)
 	ResourceUtilizationUpsert(ctx context.Context, arg []gensql.ResourceUtilizationUpsertParams) *gensql.ResourceUtilizationUpsertBatchResults
 	SpecificResourceUtilizationForApp(ctx context.Context, environment string, teamSlug slug.Slug, app string, resourceType gensql.ResourceType, timestamp pgtype.Timestamptz) (*gensql.SpecificResourceUtilizationForAppRow, error)
-	SpecificResourceUtilizationForTeam(ctx context.Context, teamSlug slug.Slug, resourceType gensql.ResourceType, timestamp pgtype.Timestamptz) (*gensql.SpecificResourceUtilizationForTeamRow, error)
+	SpecificResourceUtilizationForTeam(ctx context.Context, teamSlug slug.Slug, resourceType gensql.ResourceType, timestamp pgtype.Timestamptz) ([]*gensql.SpecificResourceUtilizationForTeamRow, error)
 }
 
 var _ ResourceUtilizationRepo = (*database)(nil)
@@ -83,7 +83,7 @@ func (d *database) SpecificResourceUtilizationForApp(ctx context.Context, enviro
 	})
 }
 
-func (d *database) SpecificResourceUtilizationForTeam(ctx context.Context, teamSlug slug.Slug, resourceType gensql.ResourceType, timestamp pgtype.Timestamptz) (*gensql.SpecificResourceUtilizationForTeamRow, error) {
+func (d *database) SpecificResourceUtilizationForTeam(ctx context.Context, teamSlug slug.Slug, resourceType gensql.ResourceType, timestamp pgtype.Timestamptz) ([]*gensql.SpecificResourceUtilizationForTeamRow, error) {
 	return d.querier.SpecificResourceUtilizationForTeam(ctx, gensql.SpecificResourceUtilizationForTeamParams{
 		TeamSlug:     teamSlug,
 		ResourceType: resourceType,


### PR DESCRIPTION
cost

When calculating trends and utilization, we want to include the overuse. This PR switches to return up to two rows when requesting data which previusly discarded in the case where usage was higher than request.

The code is not pretty, but seems to provide better values in the case mentioned in #24 
![image](https://github.com/nais/api/assets/85170275/a3ff366a-c425-45d8-9af2-b9a263e11554)

Fixes #24 