### PR TITLE
k8s/apps: ignore token generators for zero trust

### DIFF
--- a/internal/k8s/naisjobs.go
+++ b/internal/k8s/naisjobs.go
@@ -110,8 +110,7 @@ func (c *Client) setJobHasMutualOnOutbound(ctx context.Context, oJob, oTeam, oEn
 		outboundTeam = outboundRule.Namespace
 	}
 
-	if outboundRule.Application == "*" {
-		outboundRule.Mutual = true
+	if isImplicitMutual(oEnv, outboundRule) {
 		return nil
 	}
 
@@ -169,8 +168,7 @@ func (c *Client) setJobHasMutualOnInbound(ctx context.Context, oApp, oTeam, oEnv
 		inboundTeam = inboundRule.Namespace
 	}
 
-	if inboundRule.Application == "*" {
-		inboundRule.Mutual = true
+	if isImplicitMutual(oEnv, inboundRule) {
 		return nil
 	}
 


### PR DESCRIPTION
Ignore missing outbound policies for token generators to reduce some noise in Console.

Relates to #52 (but doesn't really fix it)