### PR TITLE
fix(datbases): charset and collation can be null

### DIFF
--- a/internal/graph/gengql/generated.go
+++ b/internal/graph/gengql/generated.go
@@ -47102,9 +47102,9 @@ func (ec *executionContext) _SqlDatabase_charset(ctx context.Context, field grap
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SqlDatabase_charset(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -47146,9 +47146,9 @@ func (ec *executionContext) _SqlDatabase_collation(ctx context.Context, field gr
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(string)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_SqlDatabase_collation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {

--- a/internal/graph/model/sqldatabase.go
+++ b/internal/graph/model/sqldatabase.go
@@ -15,8 +15,8 @@ import (
 )
 
 type SQLDatabase struct {
-	Charset        *string      `json:"charset"`
-	Collation      *string      `json:"collation"`
+	Charset        string       `json:"charset"`
+	Collation      string       `json:"collation"`
 	DeletionPolicy *string      `json:"deletionPolicy"`
 	InstanceRef    string       `json:"instanceRef"`
 	Healthy        bool         `json:"healthy"`
@@ -42,8 +42,8 @@ func ToSqlDatabase(u *unstructured.Unstructured, sqlInstanceName, env string) (*
 	return &SQLDatabase{
 		ID:             scalar.SqlDatabaseIdent(env, slug.Slug(teamSlug), sqlDatabase.GetName()),
 		Name:           ptr.Deref(sqlDatabase.Spec.ResourceID, "UNKNOWN"), // actual postgresql database name
-		Charset:        sqlDatabase.Spec.Charset,
-		Collation:      sqlDatabase.Spec.Collation,
+		Charset:        ptr.Deref(sqlDatabase.Spec.Charset, "UNKNOWN"),
+		Collation:      ptr.Deref(sqlDatabase.Spec.Collation, "UNKNOWN"),
 		DeletionPolicy: sqlDatabase.Spec.DeletionPolicy,
 		InstanceRef:    sqlDatabase.Spec.InstanceRef.Name,
 		Healthy:        IsHealthy(sqlDatabase.Status.Conditions),


### PR DESCRIPTION
Fixes the issues with:
`"input: team.sqlInstance.database.charset the requested element is null which the schema does not allow","level":"error","msg":"unhandled error: \"input: team.sqlInstance.database.charse t the requested element is null which the schema does not allow\"`