### PR TITLE
Add mapping of environment names

### DIFF
--- a/charts/Feature.yaml
+++ b/charts/Feature.yaml
@@ -174,6 +174,12 @@ values:
     computed:
       template: '"{{ .Management.bifrost_unleash_namespace}}"'
 
+  replaceEnvironmentNames:
+    displayName: Replace environment names
+    description: Mapping of environment names from current name to expected name. Format `currentName1:expectedName1,currentName2:expectedName2`
+    config:
+      type: string
+
   replicas:
     displayName: Number of replicas
     description: The number of replicas to run

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
             - name: USERSYNC_ADMIN_GROUP_PREFIX
               value: "{{ .Values.usersync.adminGroupPrefix }}"
             {{- end }}
+            {{- if .Values.replaceEnvironmentNames }}
+            - name: REPLACE_ENVIRONMENT_NAMES
+              value: {{ .Values.replaceEnvironmentNames | quote }}
+            {{- end }}
           envFrom:
             - secretRef:
                 name: "{{ .Release.Name }}"

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -57,6 +57,8 @@ slack:
 
 staticServiceAccounts: "" # mapped in fasit
 
+replaceEnvironmentNames: null # mapped in fasit
+
 usersync:
   serviceAccount: null # Config in fasit
   subjectEmail: null # Config in fasit

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -92,7 +92,7 @@ func run(ctx context.Context, cfg *Config, log logrus.FieldLogger) error {
 	}
 	defer pool.Close()
 
-	if err := syncEnvironments(ctx, pool, cfg.K8s.ClusterList()); err != nil {
+	if err := syncEnvironments(ctx, pool, cfg.K8s.ClusterList(), cfg.ReplaceEnvironmentNames); err != nil {
 		return err
 	}
 
@@ -109,6 +109,7 @@ func run(ctx context.Context, cfg *Config, log logrus.FieldLogger) error {
 	if cfg.WithFakeClients {
 		watcherOpts = append(watcherOpts, watcher.WithClientCreator(fake.Clients(os.DirFS("./data/k8s"))))
 	}
+	watcherOpts = append(watcherOpts, watcher.WithReplaceEnvironmentNames(cfg.ReplaceEnvironmentNames))
 
 	clusterConfig, err := kubernetes.CreateClusterConfigMap(cfg.Tenant, cfg.K8s.Clusters, cfg.K8s.StaticClusters)
 	if err != nil {

--- a/internal/cmd/api/config.go
+++ b/internal/cmd/api/config.go
@@ -131,6 +131,8 @@ type Config struct {
 	LeaseName      string `env:"LEASE_NAME,default=nais-api-lease"`
 	LeaseNamespace string `env:"LEASE_NAMESPACE,default=nais-system"`
 
+	ReplaceEnvironmentNames map[string]string `env:"REPLACE_ENVIRONMENT_NAMES, noinit"`
+
 	K8s             k8sConfig
 	Usersync        usersyncConfig
 	Cost            costConfig

--- a/internal/cmd/api/environments.go
+++ b/internal/cmd/api/environments.go
@@ -8,12 +8,17 @@ import (
 	"github.com/nais/api/internal/environment"
 )
 
-func syncEnvironments(ctx context.Context, pool *pgxpool.Pool, clusters ClusterList) error {
+func syncEnvironments(ctx context.Context, pool *pgxpool.Pool, clusters ClusterList, replaceNames map[string]string) error {
 	ctx = database.NewLoaderContext(ctx, pool)
 	ctx = environment.NewLoaderContext(ctx, pool)
 
 	syncEnvs := make([]*environment.Environment, 0)
 	for name, env := range clusters {
+		if replaceNames != nil {
+			if replaceName, ok := replaceNames[name]; ok {
+				name = replaceName
+			}
+		}
 		syncEnvs = append(syncEnvs, &environment.Environment{
 			Name: name,
 			GCP:  env.GCP,

--- a/internal/kubernetes/watcher/watcher.go
+++ b/internal/kubernetes/watcher/watcher.go
@@ -63,6 +63,9 @@ func newWatcher[T Object](mgr *Manager, obj T, settings *watcherSettings, log lo
 		resourceCounter: mgr.resourceCounter,
 	}
 	for cluster, client := range mgr.managers {
+		if mgr.replaceEnvironmentNames != nil && mgr.replaceEnvironmentNames[cluster] != "" {
+			cluster = mgr.replaceEnvironmentNames[cluster]
+		}
 		watcher, gvr := newClusterWatcher(client, cluster, w, obj, settings, log.WithField("cluster", cluster))
 		if !watcher.isRegistered {
 			continue


### PR DESCRIPTION
When creating a cluster watcher, use the mapped name if given.

This allows us to rename a environment in Fasit, but still show and support the old name