### PR TITLE
Do not create a failed job status if the job is running

### DIFF
--- a/integration_tests/k8s_resources/status/dev/slug-1/job-failed-but-running.yaml
+++ b/integration_tests/k8s_resources/status/dev/slug-1/job-failed-but-running.yaml
@@ -1,0 +1,155 @@
+apiVersion: nais.io/v1
+kind: Naisjob
+metadata:
+  finalizers:
+    - naiserator.nais.io/finalizer
+  labels:
+    team: slug-1
+  name: job-failed-running
+  namespace: slug-1
+spec:
+  accessPolicy:
+    outbound:
+      external:
+        - host: storage.googleapis.com
+        - host: www.googleapis.com
+  backoffLimit: 5
+  completions: 1
+  failedJobsHistoryLimit: 3
+  filesFrom:
+    - emptyDir:
+        medium: Memory
+      mountPath: /.config
+  image: europe-north1-docker.pkg.dev/nais/navikt/app-name:latest
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
+  restartPolicy: OnFailure
+  schedule: 15 0 * * *
+  skipCaBundle: true
+  successfulJobsHistoryLimit: 1
+  timeZone: Europe/Oslo
+status:
+  conditions:
+    - lastTransitionTime: "2025-03-27T08:23:46Z"
+      message: Successfully deployed.
+      reason: RolloutComplete
+      status: "True"
+      type: SynchronizationState
+  correlationID: 1dd3c3f8-33d3-4f2a-bed0-d2a96b3ada3b
+  deploymentRolloutStatus: complete
+  effectiveImage: europe-north1-docker.pkg.dev/nais/navikt/app-name:latest
+  rolloutCompleteTime: 1743063831960111589
+  synchronizationHash: ca9731d8fd3fc204
+  synchronizationState: RolloutComplete
+  synchronizationTime: 1743063826951125196
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    batch.kubernetes.io/cronjob-scheduled-timestamp: "2025-06-10T00:15:00+02:00"
+  labels:
+    app: job-failed-running
+    team: slug-1
+  name: job-failed-running-29158455
+  namespace: slug-1
+  ownerReferences:
+    - apiVersion: batch/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CronJob
+      name: job-failed-running
+      uid: 4c0f4cce-8688-46f3-b2c8-9115064c2d17
+spec:
+  backoffLimit: 5
+  completionMode: NonIndexed
+  completions: 1
+  manualSelector: false
+  parallelism: 1
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+    matchLabels:
+      batch.kubernetes.io/controller-uid: 48c8f149-dd55-428f-af5d-049ebf260df4
+  suspend: false
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: job-failed-running
+      creationTimestamp: null
+      labels:
+        app: job-failed-running
+        batch.kubernetes.io/job-name: job-failed-running-29158455
+        controller-uid: 48c8f149-dd55-428f-af5d-049ebf260df4
+        job-name: job-failed-running-29158455
+        nais.io/naisjob: "true"
+        team: slug-1
+      name: job-failed-running
+      namespace: slug-1
+      ownerReferences:
+        - apiVersion: nais.io/v1
+          kind: Naisjob
+          name: job-failed-running
+          uid: f32fccd4-5843-4949-9390-1e837253f0b0
+    spec:
+      containers:
+        - image: europe-north1-docker.pkg.dev/nais/navikt/app-name:latest
+          imagePullPolicy: IfNotPresent
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: 5
+          name: job-failed-running
+          resources:
+            limits:
+              cpu: "1"
+              memory: 512Mi
+            requests:
+              cpu: 200m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1069
+            runAsNonRoot: true
+            runAsUser: 1069
+            seccompProfile:
+              type: RuntimeDefault
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /.config
+              name: config
+            - mountPath: /tmp
+              name: writable-tmp
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      securityContext:
+        fsGroup: 1069
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccount: job-failed-running
+      serviceAccountName: job-failed-running
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - emptyDir:
+            medium: Memory
+          name: config
+        - emptyDir: {}
+          name: writable-tmp
+status:
+  active: 1
+  failed: 1
+  ready: 1
+  startTime: "2025-06-09T22:15:00Z"
+  terminating: 0
+  uncountedTerminatedPods: {}

--- a/integration_tests/k8s_resources/status_workload_filter/dev/slug-1/job-failing.yaml
+++ b/integration_tests/k8s_resources/status_workload_filter/dev/slug-1/job-failing.yaml
@@ -21,4 +21,5 @@ spec:
           image: europe-north1-docker.pkg.dev/nais/navikt/app-name:latest
 status:
   startTime: "2023-10-01T12:00:00Z"
+  completionTime: "2023-10-01T12:00:00Z"
   failed: 3

--- a/integration_tests/status_for_jobs.lua
+++ b/integration_tests/status_for_jobs.lua
@@ -151,59 +151,23 @@ Test.gql("job with naiserator failed synchronization", function(t)
 	}
 end)
 
+Test.gql("job that failed, but is running", function(t)
+	t.addHeader("x-user-email", user:email())
 
--- Test.gql("job with failing netpols", function(t)
--- 	t.addHeader("x-user-email", user:email())
+	t.query(statusQuery("slug-1", "dev", "job-failed-running"))
 
--- 	t.query(statusQuery("slug-1", "dev", "failed-netpol", [[
--- 		... on WorkloadStatusInboundNetwork {
--- 			policy {
--- 				targetWorkloadName
--- 				targetTeamSlug
--- 				mutual
--- 			}
--- 		}
--- 		... on WorkloadStatusOutboundNetwork {
--- 			policy {
--- 				targetWorkloadName
--- 				targetTeamSlug
--- 				mutual
--- 			}
--- 		}
--- 	]]))
-
--- 	t.check {
--- 		data = {
--- 			team = {
--- 				environment = {
--- 					job = {
--- 						status = {
--- 							state = "NOT_NAIS",
--- 							errors = {
--- 								{
--- 									__typename = "WorkloadStatusInboundNetwork",
--- 									level = "WARNING",
--- 									policy = {
--- 										mutual = false,
--- 										targetTeamSlug = "other-namespace",
--- 										targetWorkloadName = "other-app",
--- 									},
--- 								},
--- 								{
--- 									__typename = "WorkloadStatusOutboundNetwork",
--- 									level = "WARNING",
--- 									policy = {
--- 										mutual = false,
--- 										targetTeamSlug = "other-namespace",
--- 										targetWorkloadName = "other-app",
--- 									},
--- 								},
--- 								expectedMissingSBOM,
--- 							},
--- 						},
--- 					},
--- 				},
--- 			},
--- 		},
--- 	}
--- end)
+	t.check {
+		data = {
+			team = {
+				environment = {
+					job = {
+						status = {
+							state = "NAIS",
+							errors = {},
+						},
+					},
+				},
+			},
+		},
+	}
+end)

--- a/internal/workload/job/models.go
+++ b/internal/workload/job/models.go
@@ -78,6 +78,7 @@ type JobRun struct {
 	TeamSlug        slug.Slug      `json:"-"`
 	Failed          bool           `json:"-"`
 	Message         string         `json:"-"`
+	Ready           int            `json:"ready"`
 
 	spec *batchv1.Job
 }


### PR DESCRIPTION
This changes so that the job will not have a status as failed if it is actively running.

It also fixes the status for one other job created for testing, as well as removed an outdated comment.