### PR TITLE
feat(vulnerability): add Mean Time To Fix

### DIFF
--- a/internal/graph/schema/vulnerability.graphqls
+++ b/internal/graph/schema/vulnerability.graphqls
@@ -545,3 +545,55 @@ extend enum ActivityLogActivityType {
 	"Activity log entry for when a vulnerability is updated."
 	VULNERABILITY_UPDATED
 }
+
+extend type Query {
+	"Get the mean time to fix history for all teams."
+	meanTimeToFixHistory(from: Date!): MeanTimeToFixHistory!
+}
+
+extend interface Workload {
+	"Get the mean time to fix history for a workload."
+	meanTimeToFixHistory(from: Date!): MeanTimeToFixHistory!
+}
+
+extend type Application {
+	"Get the mean time to fix history for an application."
+	meanTimeToFixHistory(from: Date!): MeanTimeToFixHistory!
+}
+
+extend type Job {
+	"Get the mean time to fix history for a job."
+	meanTimeToFixHistory(from: Date!): MeanTimeToFixHistory!
+}
+
+extend type Team {
+	"Get the mean time to fix history for a team."
+	meanTimeToFixHistory(from: Date!): MeanTimeToFixHistory!
+}
+
+"Trend of mean time to fix vulnerabilities grouped by severity."
+type MeanTimeToFixHistory {
+	"Mean time to fix samples."
+	samples: [MeanTimeToFixSample!]!
+}
+
+"One MTTR sample for a severity at a point in time."
+type MeanTimeToFixSample {
+	"Severity of vulnerabilities in this sample."
+	severity: ImageVulnerabilitySeverity!
+
+	"Snapshot date of the sample."
+	date: Time!
+
+	"Mean time to fix in days."
+	days: Int!
+
+	"Number of vulnerabilities fixed in this sample."
+	fixedCount: Int!
+
+	"Earliest time a vulnerability was fixed in this sample."
+	firstFixedAt: Time
+
+	"Latest time a vulnerability was fixed in this sample."
+	lastFixedAt: Time
+}

--- a/internal/graph/vulnerability.resolvers.go
+++ b/internal/graph/vulnerability.resolvers.go
@@ -20,6 +20,10 @@ func (r *applicationResolver) ImageVulnerabilityHistory(ctx context.Context, obj
 	return vulnerability.GetWorkloadVulnerabilityHistoryForWorkload(ctx, obj, from.Time())
 }
 
+func (r *applicationResolver) MeanTimeToFixHistory(ctx context.Context, obj *application.Application, from scalar.Date) (*vulnerability.MeanTimeToFixHistory, error) {
+	return vulnerability.GetMeanTimeToFixHistoryForWorkload(ctx, obj, from.Time())
+}
+
 func (r *containerImageResolver) HasSbom(ctx context.Context, obj *workload.ContainerImage) (bool, error) {
 	return vulnerability.GetImageHasSBOM(ctx, obj.Ref())
 }
@@ -54,6 +58,10 @@ func (r *jobResolver) ImageVulnerabilityHistory(ctx context.Context, obj *job.Jo
 	return vulnerability.GetWorkloadVulnerabilityHistoryForWorkload(ctx, obj, from.Time())
 }
 
+func (r *jobResolver) MeanTimeToFixHistory(ctx context.Context, obj *job.Job, from scalar.Date) (*vulnerability.MeanTimeToFixHistory, error) {
+	return vulnerability.GetMeanTimeToFixHistoryForWorkload(ctx, obj, from.Time())
+}
+
 func (r *mutationResolver) UpdateImageVulnerability(ctx context.Context, input vulnerability.UpdateImageVulnerabilityInput) (*vulnerability.UpdateImageVulnerabilityPayload, error) {
 	vulnWorkloads, err := vulnerability.ListWorkloadsForVulnerabilityByID(ctx, input.VulnerabilityID.ID)
 	if err != nil {
@@ -83,6 +91,10 @@ func (r *queryResolver) VulnerabilitySummary(ctx context.Context) (*vulnerabilit
 	return vulnerability.GetTenantVulnerabilitySummary(ctx)
 }
 
+func (r *queryResolver) MeanTimeToFixHistory(ctx context.Context, from scalar.Date) (*vulnerability.MeanTimeToFixHistory, error) {
+	return vulnerability.GetMeanTimeToFixHistory(ctx, from.Time())
+}
+
 func (r *teamResolver) ImageVulnerabilityHistory(ctx context.Context, obj *team.Team, from scalar.Date) (*vulnerability.ImageVulnerabilityHistory, error) {
 	return vulnerability.GetWorkloadVulnerabilityHistoryForTeam(ctx, obj.Slug, from.Time())
 }
@@ -98,6 +110,10 @@ func (r *teamResolver) VulnerabilitySummaries(ctx context.Context, obj *team.Tea
 	}
 
 	return vulnerability.ListVulnerabilitySummaries(ctx, obj.Slug, filter, page, orderBy)
+}
+
+func (r *teamResolver) MeanTimeToFixHistory(ctx context.Context, obj *team.Team, from scalar.Date) (*vulnerability.MeanTimeToFixHistory, error) {
+	return vulnerability.GetMeanTimeToFixHistoryForTeam(ctx, obj.Slug, from.Time())
 }
 
 func (r *teamVulnerabilitySummaryResolver) RiskScoreTrend(ctx context.Context, obj *vulnerability.TeamVulnerabilitySummary) (vulnerability.TeamVulnerabilityRiskScoreTrend, error) {

--- a/internal/vulnerability/models.go
+++ b/internal/vulnerability/models.go
@@ -376,3 +376,17 @@ type TenantVulnerabilitySummary struct {
 	Coverage    float64    `json:"coverage"`
 	LastUpdated *time.Time `json:"lastUpdated"`
 }
+
+type MeanTimeToFixHistory struct {
+	Samples []*MeanTimeToFixSample `json:"samples"`
+}
+
+type MeanTimeToFixSample struct {
+	Severity       ImageVulnerabilitySeverity `json:"severity"`
+	Date           time.Time                  `json:"date"`
+	Days           int                        `json:"days"`
+	FixedCount     int                        `json:"fixedCount"`
+	FirstFixedAt   *time.Time                 `json:"firstFixedAt,omitempty"`
+	LastFixedAt    *time.Time                 `json:"lastFixedAt,omitempty"`
+	TotalWorkloads int                        `json:"totalWorkloads"`
+}

--- a/internal/vulnerability/queries.go
+++ b/internal/vulnerability/queries.go
@@ -557,6 +557,110 @@ func GetVulnerabilitySummary(ctx context.Context, s slug.Slug, filter *TeamVulne
 	}, nil
 }
 
+func GetMeanTimeToFixHistoryForWorkload(ctx context.Context, obj workload.Workload, from time.Time) (*MeanTimeToFixHistory, error) {
+	workloadType, err := getWorkloadType(obj.GetType())
+	if err != nil {
+		return nil, err
+	}
+
+	if from.Before(time.Now().AddDate(-1, 0, 0)) {
+		return nil, apierror.Errorf("`from` cannot be older than 1 year")
+	}
+	if from.After(time.Now()) {
+		return nil, apierror.Errorf("`from` cannot be in the future")
+	}
+
+	since := normalizeFromDate(from)
+	var opts []vulnerabilities.Option
+	opts = append(opts, vulnerabilities.Since(since))
+	opts = append(opts, vulnerabilities.ClusterFilter(environmentmapper.ClusterName(obj.GetEnvironmentName())))
+	opts = append(opts, vulnerabilities.NamespaceFilter(obj.GetTeamSlug().String()))
+	opts = append(opts, vulnerabilities.WorkloadFilter(obj.GetName()))
+	opts = append(opts, vulnerabilities.WorkloadTypeFilter(workloadType))
+
+	return getMeanTimeToFixHistory(ctx, opts)
+}
+
+func GetMeanTimeToFixHistoryForTeam(ctx context.Context, slug slug.Slug, from time.Time) (*MeanTimeToFixHistory, error) {
+	if from.Before(time.Now().AddDate(-1, 0, 0)) {
+		return nil, apierror.Errorf("`from` cannot be older than 1 year")
+	}
+	if from.After(time.Now()) {
+		return nil, apierror.Errorf("`from` cannot be in the future")
+	}
+
+	since := normalizeFromDate(from)
+
+	opts := []vulnerabilities.Option{}
+	opts = append(opts, vulnerabilities.Since(since))
+	opts = append(opts, vulnerabilities.NamespaceFilter(slug.String()))
+
+	return getMeanTimeToFixHistory(ctx, opts)
+}
+
+func GetMeanTimeToFixHistory(ctx context.Context, from time.Time) (*MeanTimeToFixHistory, error) {
+	var opts []vulnerabilities.Option
+	opts = append(opts, vulnerabilities.Since(from))
+	return getMeanTimeToFixHistory(ctx, opts)
+}
+
+func getMeanTimeToFixHistory(ctx context.Context, opts []vulnerabilities.Option) (*MeanTimeToFixHistory, error) {
+	resp, err := fromContext(ctx).Client.ListMeanTimeToFixTrendBySeverity(ctx, opts...)
+	if err != nil {
+		return nil, apierror.Errorf("list mean time to fix trend by severity: %v", err)
+	}
+
+	samples := make([]*MeanTimeToFixSample, 0, len(resp.GetPoints()))
+	for _, point := range resp.GetPoints() {
+		firstFixedAt := point.GetFirstFixedAt().AsTime()
+		lastFixedAt := point.GetLastFixedAt().AsTime()
+		sample := &MeanTimeToFixSample{
+			Severity:       parseSeverity(point.Severity),
+			Date:           point.SnapshotDate.AsTime(),
+			Days:           int(point.GetMeanTimeToFixDays()),
+			FixedCount:     int(point.FixedCount),
+			FirstFixedAt:   &firstFixedAt,
+			LastFixedAt:    &lastFixedAt,
+			TotalWorkloads: int(point.WorkloadCount),
+		}
+		samples = append(samples, sample)
+	}
+
+	sort.Slice(samples, func(i, j int) bool {
+		return samples[i].Date.After(samples[j].Date)
+	})
+
+	return &MeanTimeToFixHistory{
+		Samples: samples,
+	}, nil
+}
+
+func getWorkloadType(workloadType workload.Type) (string, error) {
+	switch workloadType {
+	case workload.TypeApplication:
+		return "app", nil
+	case workload.TypeJob:
+		return "job", nil
+	default:
+		return "", apierror.Errorf("invalid workload type: %s", workloadType)
+	}
+}
+
+func parseSeverity(s vulnerabilities.Severity) ImageVulnerabilitySeverity {
+	switch s {
+	case vulnerabilities.Severity_CRITICAL:
+		return ImageVulnerabilitySeverityCritical
+	case vulnerabilities.Severity_HIGH:
+		return ImageVulnerabilitySeverityHigh
+	case vulnerabilities.Severity_MEDIUM:
+		return ImageVulnerabilitySeverityMedium
+	case vulnerabilities.Severity_LOW:
+		return ImageVulnerabilitySeverityLow
+	default:
+		return ImageVulnerabilitySeverityUnassigned
+	}
+}
+
 func getVulnerabilityByIdent(ctx context.Context, id ident.Ident) (*ImageVulnerability, error) {
 	resp, err := fromContext(ctx).Client.GetVulnerabilityById(ctx, id.ID)
 	if err != nil {


### PR DESCRIPTION
Introduces a new feature to track and query the mean time to fix (MTTR) vulnerabilities, enabling users to analyze how quickly vulnerabilities are resolved over time, grouped by severity. 

The implementation spans GraphQL schema updates, resolver additions, model definitions, and query logic.