### PR TITLE
feature(fasit): dual-serve nais-api ingress via HAProxy and nginx

### DIFF
--- a/charts/templates/ingress.yaml
+++ b/charts/templates/ingress.yaml
@@ -9,8 +9,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Robots-Tag: noindex";
+    haproxy.org/response-set-header: "X-Robots-Tag noindex"
 spec:
-  ingressClassName: "nais-ingress-external"
+  ingressClassName: {{ .Values.ingressClassName }}
   rules:
     - host: "{{ .Values.host }}"
       http:
@@ -43,3 +44,53 @@ spec:
                   name: rest
             path: /api/v1/
             pathType: Prefix
+---
+{{- range .Values.additionalIngressClassNames }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ $.Release.Name }}-{{ . }}"
+  labels:
+    app: "{{ $.Release.Name }}"
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Robots-Tag: noindex";
+    haproxy.org/response-set-header: "X-Robots-Tag noindex"
+spec:
+  ingressClassName: {{ . }}
+  rules:
+    - host: "{{ $.Values.host }}"
+      http:
+        paths:
+          - backend:
+              service:
+                name: "{{ $.Release.Name }}"
+                port:
+                  name: http
+            path: /graphql
+            pathType: Prefix
+          - backend:
+              service:
+                name: "{{ $.Release.Name }}"
+                port:
+                  name: http
+            path: /oauth2/
+            pathType: Prefix
+          - backend:
+              service:
+                name: "{{ $.Release.Name }}"
+                port:
+                  name: rest
+            path: /teams/
+            pathType: Prefix
+          - backend:
+              service:
+                name: "{{ $.Release.Name }}"
+                port:
+                  name: rest
+            path: /api/v1/
+            pathType: Prefix
+---
+{{- end }}

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -18,6 +18,10 @@ image:
 
 host: ""
 
+ingressClassName: external-haproxy
+additionalIngressClassNames:
+  - nais-ingress-external
+
 rest:
   psk: ""
 


### PR DESCRIPTION
Enable zero-downtime migration from `nais-ingress-external` to `external-haproxy` by serving traffic through both controllers.

Next steps:
- `helm upgrade` to dev cluster (human operator)
- Verify both ingresses get an ADDRESS via `kubectl get ingress`
- Once migration is complete, delete `additionalIngressClassNames`