### PR TITLE
Add restart loop detection for applications

### DIFF
--- a/internal/graph/gengql/applications.generated.go
+++ b/internal/graph/gengql/applications.generated.go
@@ -2869,6 +2869,8 @@ func (ec *executionContext) fieldContext_ApplicationInstance_status(_ context.Co
 				return ec.fieldContext_ApplicationInstanceStatus_lastExitReason(ctx, field)
 			case "lastExitCode":
 				return ec.fieldContext_ApplicationInstanceStatus_lastExitCode(ctx, field)
+			case "lastExitTimestamp":
+				return ec.fieldContext_ApplicationInstanceStatus_lastExitTimestamp(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ApplicationInstanceStatus", field.Name)
 		},
@@ -3260,6 +3262,35 @@ func (ec *executionContext) fieldContext_ApplicationInstanceStatus_lastExitCode(
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ApplicationInstanceStatus_lastExitTimestamp(ctx context.Context, field graphql.CollectedField, obj *application.ApplicationInstanceStatus) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ApplicationInstanceStatus_lastExitTimestamp,
+		func(ctx context.Context) (any, error) {
+			return obj.LastExitTimestamp, nil
+		},
+		nil,
+		ec.marshalOTime2ᚖtimeᚐTime,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ApplicationInstanceStatus_lastExitTimestamp(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ApplicationInstanceStatus",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -6679,6 +6710,8 @@ func (ec *executionContext) _ApplicationInstanceStatus(ctx context.Context, sel 
 			out.Values[i] = ec._ApplicationInstanceStatus_lastExitReason(ctx, field, obj)
 		case "lastExitCode":
 			out.Values[i] = ec._ApplicationInstanceStatus_lastExitCode(ctx, field, obj)
+		case "lastExitTimestamp":
+			out.Values[i] = ec._ApplicationInstanceStatus_lastExitTimestamp(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/graph/gengql/issues.generated.go
+++ b/internal/graph/gengql/issues.generated.go
@@ -70,6 +70,11 @@ type OpenSearchIssueResolver interface {
 
 	OpenSearch(ctx context.Context, obj *issue.OpenSearchIssue) (*opensearch.OpenSearch, error)
 }
+type RestartLoopIssueResolver interface {
+	TeamEnvironment(ctx context.Context, obj *issue.RestartLoopIssue) (*team.TeamEnvironment, error)
+
+	Workload(ctx context.Context, obj *issue.RestartLoopIssue) (workload.Workload, error)
+}
 type SqlInstanceStateIssueResolver interface {
 	TeamEnvironment(ctx context.Context, obj *issue.SqlInstanceStateIssue) (*team.TeamEnvironment, error)
 
@@ -2238,6 +2243,280 @@ func (ec *executionContext) fieldContext_OpenSearchIssue_event(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _RestartLoopIssue_id(ctx context.Context, field graphql.CollectedField, obj *issue.RestartLoopIssue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RestartLoopIssue_id,
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		ec.marshalNID2githubᚗcomᚋnaisᚋapiᚋinternalᚋgraphᚋidentᚐIdent,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RestartLoopIssue_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RestartLoopIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RestartLoopIssue_teamEnvironment(ctx context.Context, field graphql.CollectedField, obj *issue.RestartLoopIssue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RestartLoopIssue_teamEnvironment,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.RestartLoopIssue().TeamEnvironment(ctx, obj)
+		},
+		nil,
+		ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RestartLoopIssue_teamEnvironment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RestartLoopIssue",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_TeamEnvironment_id(ctx, field)
+			case "name":
+				return ec.fieldContext_TeamEnvironment_name(ctx, field)
+			case "gcpProjectID":
+				return ec.fieldContext_TeamEnvironment_gcpProjectID(ctx, field)
+			case "slackAlertsChannel":
+				return ec.fieldContext_TeamEnvironment_slackAlertsChannel(ctx, field)
+			case "team":
+				return ec.fieldContext_TeamEnvironment_team(ctx, field)
+			case "alerts":
+				return ec.fieldContext_TeamEnvironment_alerts(ctx, field)
+			case "application":
+				return ec.fieldContext_TeamEnvironment_application(ctx, field)
+			case "bigQueryDataset":
+				return ec.fieldContext_TeamEnvironment_bigQueryDataset(ctx, field)
+			case "bucket":
+				return ec.fieldContext_TeamEnvironment_bucket(ctx, field)
+			case "config":
+				return ec.fieldContext_TeamEnvironment_config(ctx, field)
+			case "cost":
+				return ec.fieldContext_TeamEnvironment_cost(ctx, field)
+			case "environment":
+				return ec.fieldContext_TeamEnvironment_environment(ctx, field)
+			case "job":
+				return ec.fieldContext_TeamEnvironment_job(ctx, field)
+			case "kafkaTopic":
+				return ec.fieldContext_TeamEnvironment_kafkaTopic(ctx, field)
+			case "openSearch":
+				return ec.fieldContext_TeamEnvironment_openSearch(ctx, field)
+			case "postgresInstance":
+				return ec.fieldContext_TeamEnvironment_postgresInstance(ctx, field)
+			case "secret":
+				return ec.fieldContext_TeamEnvironment_secret(ctx, field)
+			case "sqlInstance":
+				return ec.fieldContext_TeamEnvironment_sqlInstance(ctx, field)
+			case "valkey":
+				return ec.fieldContext_TeamEnvironment_valkey(ctx, field)
+			case "workload":
+				return ec.fieldContext_TeamEnvironment_workload(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TeamEnvironment", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RestartLoopIssue_severity(ctx context.Context, field graphql.CollectedField, obj *issue.RestartLoopIssue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RestartLoopIssue_severity,
+		func(ctx context.Context) (any, error) {
+			return obj.Severity, nil
+		},
+		nil,
+		ec.marshalNSeverity2githubᚗcomᚋnaisᚋapiᚋinternalᚋissueᚐSeverity,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RestartLoopIssue_severity(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RestartLoopIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Severity does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RestartLoopIssue_message(ctx context.Context, field graphql.CollectedField, obj *issue.RestartLoopIssue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RestartLoopIssue_message,
+		func(ctx context.Context) (any, error) {
+			return obj.Message, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RestartLoopIssue_message(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RestartLoopIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RestartLoopIssue_workload(ctx context.Context, field graphql.CollectedField, obj *issue.RestartLoopIssue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RestartLoopIssue_workload,
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.RestartLoopIssue().Workload(ctx, obj)
+		},
+		nil,
+		ec.marshalNWorkload2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐWorkload,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RestartLoopIssue_workload(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RestartLoopIssue",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RestartLoopIssue_restartCount(ctx context.Context, field graphql.CollectedField, obj *issue.RestartLoopIssue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RestartLoopIssue_restartCount,
+		func(ctx context.Context) (any, error) {
+			return obj.RestartCount, nil
+		},
+		nil,
+		ec.marshalNInt2int,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RestartLoopIssue_restartCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RestartLoopIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RestartLoopIssue_lastExitReason(ctx context.Context, field graphql.CollectedField, obj *issue.RestartLoopIssue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RestartLoopIssue_lastExitReason,
+		func(ctx context.Context) (any, error) {
+			return obj.LastExitReason, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RestartLoopIssue_lastExitReason(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RestartLoopIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RestartLoopIssue_lastExitTimestamp(ctx context.Context, field graphql.CollectedField, obj *issue.RestartLoopIssue) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RestartLoopIssue_lastExitTimestamp,
+		func(ctx context.Context) (any, error) {
+			return obj.LastExitTimestamp, nil
+		},
+		nil,
+		ec.marshalNTime2timeᚐTime,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RestartLoopIssue_lastExitTimestamp(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RestartLoopIssue",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SqlInstanceStateIssue_id(ctx context.Context, field graphql.CollectedField, obj *issue.SqlInstanceStateIssue) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -3715,6 +3994,13 @@ func (ec *executionContext) _Issue(ctx context.Context, sel ast.SelectionSet, ob
 			return graphql.Null
 		}
 		return ec._SqlInstanceStateIssue(ctx, sel, obj)
+	case issue.RestartLoopIssue:
+		return ec._RestartLoopIssue(ctx, sel, &obj)
+	case *issue.RestartLoopIssue:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._RestartLoopIssue(ctx, sel, obj)
 	case issue.OpenSearchIssue:
 		return ec._OpenSearchIssue(ctx, sel, &obj)
 	case *issue.OpenSearchIssue:
@@ -4967,6 +5253,142 @@ func (ec *executionContext) _OpenSearchIssue(ctx context.Context, sel ast.Select
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "event":
 			out.Values[i] = ec._OpenSearchIssue_event(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var restartLoopIssueImplementors = []string{"RestartLoopIssue", "Issue", "Node"}
+
+func (ec *executionContext) _RestartLoopIssue(ctx context.Context, sel ast.SelectionSet, obj *issue.RestartLoopIssue) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, restartLoopIssueImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RestartLoopIssue")
+		case "id":
+			out.Values[i] = ec._RestartLoopIssue_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "teamEnvironment":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._RestartLoopIssue_teamEnvironment(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "severity":
+			out.Values[i] = ec._RestartLoopIssue_severity(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "message":
+			out.Values[i] = ec._RestartLoopIssue_message(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "workload":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._RestartLoopIssue_workload(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "restartCount":
+			out.Values[i] = ec._RestartLoopIssue_restartCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "lastExitReason":
+			out.Values[i] = ec._RestartLoopIssue_lastExitReason(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "lastExitTimestamp":
+			out.Values[i] = ec._RestartLoopIssue_lastExitTimestamp(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -99,6 +99,7 @@ type ResolverRoot interface {
 	RemoveTeamMemberPayload() RemoveTeamMemberPayloadResolver
 	Repository() RepositoryResolver
 	RestartApplicationPayload() RestartApplicationPayloadResolver
+	RestartLoopIssue() RestartLoopIssueResolver
 	Secret() SecretResolver
 	ServiceAccount() ServiceAccountResolver
 	SqlDatabase() SqlDatabaseResolver
@@ -273,11 +274,12 @@ type ComplexityRoot struct {
 	}
 
 	ApplicationInstanceStatus struct {
-		LastExitCode   func(childComplexity int) int
-		LastExitReason func(childComplexity int) int
-		Message        func(childComplexity int) int
-		Ready          func(childComplexity int) int
-		State          func(childComplexity int) int
+		LastExitCode      func(childComplexity int) int
+		LastExitReason    func(childComplexity int) int
+		LastExitTimestamp func(childComplexity int) int
+		Message           func(childComplexity int) int
+		Ready             func(childComplexity int) int
+		State             func(childComplexity int) int
 	}
 
 	ApplicationInstanceUtilization struct {
@@ -1837,6 +1839,17 @@ type ComplexityRoot struct {
 
 	RestartApplicationPayload struct {
 		Application func(childComplexity int) int
+	}
+
+	RestartLoopIssue struct {
+		ID                func(childComplexity int) int
+		LastExitReason    func(childComplexity int) int
+		LastExitTimestamp func(childComplexity int) int
+		Message           func(childComplexity int) int
+		RestartCount      func(childComplexity int) int
+		Severity          func(childComplexity int) int
+		TeamEnvironment   func(childComplexity int) int
+		Workload          func(childComplexity int) int
 	}
 
 	RevokeRoleFromServiceAccountPayload struct {
@@ -3942,6 +3955,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.ApplicationInstanceStatus.LastExitReason(childComplexity), true
+
+	case "ApplicationInstanceStatus.lastExitTimestamp":
+		if e.ComplexityRoot.ApplicationInstanceStatus.LastExitTimestamp == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ApplicationInstanceStatus.LastExitTimestamp(childComplexity), true
 
 	case "ApplicationInstanceStatus.message":
 		if e.ComplexityRoot.ApplicationInstanceStatus.Message == nil {
@@ -10842,6 +10862,62 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.RestartApplicationPayload.Application(childComplexity), true
+
+	case "RestartLoopIssue.id":
+		if e.ComplexityRoot.RestartLoopIssue.ID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RestartLoopIssue.ID(childComplexity), true
+
+	case "RestartLoopIssue.lastExitReason":
+		if e.ComplexityRoot.RestartLoopIssue.LastExitReason == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RestartLoopIssue.LastExitReason(childComplexity), true
+
+	case "RestartLoopIssue.lastExitTimestamp":
+		if e.ComplexityRoot.RestartLoopIssue.LastExitTimestamp == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RestartLoopIssue.LastExitTimestamp(childComplexity), true
+
+	case "RestartLoopIssue.message":
+		if e.ComplexityRoot.RestartLoopIssue.Message == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RestartLoopIssue.Message(childComplexity), true
+
+	case "RestartLoopIssue.restartCount":
+		if e.ComplexityRoot.RestartLoopIssue.RestartCount == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RestartLoopIssue.RestartCount(childComplexity), true
+
+	case "RestartLoopIssue.severity":
+		if e.ComplexityRoot.RestartLoopIssue.Severity == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RestartLoopIssue.Severity(childComplexity), true
+
+	case "RestartLoopIssue.teamEnvironment":
+		if e.ComplexityRoot.RestartLoopIssue.TeamEnvironment == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RestartLoopIssue.TeamEnvironment(childComplexity), true
+
+	case "RestartLoopIssue.workload":
+		if e.ComplexityRoot.RestartLoopIssue.Workload == nil {
+			break
+		}
+
+		return e.ComplexityRoot.RestartLoopIssue.Workload(childComplexity), true
 
 	case "RevokeRoleFromServiceAccountPayload.serviceAccount":
 		if e.ComplexityRoot.RevokeRoleFromServiceAccountPayload.ServiceAccount == nil {
@@ -18436,6 +18512,11 @@ type ApplicationInstanceStatus {
 	The exit code from the last container termination, if applicable.
 	"""
 	lastExitCode: Int
+	"""
+	The timestamp of the last container termination, if applicable.
+	This is populated even when the instance is currently running, to help debug restart loops.
+	"""
+	lastExitTimestamp: Time
 }
 
 enum ApplicationInstanceState {
@@ -20734,6 +20815,7 @@ enum IssueType {
 	VULNERABLE_IMAGE
 	EXTERNAL_INGRESS_CRITICAL_VULNERABILITY
 	UNLEASH_RELEASE_CHANNEL
+	RESTART_LOOP
 }
 
 type VulnerableImageIssue implements Issue & Node {
@@ -20874,6 +20956,21 @@ type UnleashReleaseChannelIssue implements Issue & Node {
 	majorVersion: Int!
 	"The current major version of Unleash available."
 	currentMajorVersion: Int!
+}
+
+type RestartLoopIssue implements Issue & Node {
+	id: ID!
+	teamEnvironment: TeamEnvironment!
+	severity: Severity!
+	message: String!
+
+	workload: Workload!
+	"The number of container restarts."
+	restartCount: Int!
+	"The reason for the last container exit."
+	lastExitReason: String!
+	"The timestamp of the last container exit."
+	lastExitTimestamp: Time!
 }
 `, BuiltIn: false},
 	{Name: "../schema/jobs.graphqls", Input: `extend type Team {

--- a/internal/graph/gengql/schema.generated.go
+++ b/internal/graph/gengql/schema.generated.go
@@ -5827,6 +5827,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._RoleAssignedToServiceAccountActivityLogEntry(ctx, sel, obj)
+	case issue.RestartLoopIssue:
+		return ec._RestartLoopIssue(ctx, sel, &obj)
+	case *issue.RestartLoopIssue:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._RestartLoopIssue(ctx, sel, obj)
 	case repository.RepositoryRemovedActivityLogEntry:
 		return ec._RepositoryRemovedActivityLogEntry(ctx, sel, &obj)
 	case *repository.RepositoryRemovedActivityLogEntry:

--- a/internal/graph/issues.resolvers.go
+++ b/internal/graph/issues.resolvers.go
@@ -88,6 +88,14 @@ func (r *openSearchIssueResolver) OpenSearch(ctx context.Context, obj *issue.Ope
 	return opensearch.Get(ctx, obj.TeamSlug, obj.EnvironmentName, obj.ResourceName)
 }
 
+func (r *restartLoopIssueResolver) TeamEnvironment(ctx context.Context, obj *issue.RestartLoopIssue) (*team.TeamEnvironment, error) {
+	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
+}
+
+func (r *restartLoopIssueResolver) Workload(ctx context.Context, obj *issue.RestartLoopIssue) (workload.Workload, error) {
+	return getWorkloadByResourceType(ctx, obj.TeamSlug, obj.EnvironmentName, obj.ResourceName, obj.ResourceType)
+}
+
 func (r *sqlInstanceStateIssueResolver) TeamEnvironment(ctx context.Context, obj *issue.SqlInstanceStateIssue) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }
@@ -173,6 +181,10 @@ func (r *Resolver) OpenSearchIssue() gengql.OpenSearchIssueResolver {
 	return &openSearchIssueResolver{r}
 }
 
+func (r *Resolver) RestartLoopIssue() gengql.RestartLoopIssueResolver {
+	return &restartLoopIssueResolver{r}
+}
+
 func (r *Resolver) SqlInstanceStateIssue() gengql.SqlInstanceStateIssueResolver {
 	return &sqlInstanceStateIssueResolver{r}
 }
@@ -201,6 +213,7 @@ type (
 	missingSbomIssueResolver                          struct{ *Resolver }
 	noRunningInstancesIssueResolver                   struct{ *Resolver }
 	openSearchIssueResolver                           struct{ *Resolver }
+	restartLoopIssueResolver                          struct{ *Resolver }
 	sqlInstanceStateIssueResolver                     struct{ *Resolver }
 	sqlInstanceVersionIssueResolver                   struct{ *Resolver }
 	unleashReleaseChannelIssueResolver                struct{ *Resolver }

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -591,6 +591,11 @@ type ApplicationInstanceStatus {
 	The exit code from the last container termination, if applicable.
 	"""
 	lastExitCode: Int
+	"""
+	The timestamp of the last container termination, if applicable.
+	This is populated even when the instance is currently running, to help debug restart loops.
+	"""
+	lastExitTimestamp: Time
 }
 
 enum ApplicationInstanceState {

--- a/internal/graph/schema/issues.graphqls
+++ b/internal/graph/schema/issues.graphqls
@@ -165,6 +165,7 @@ enum IssueType {
 	VULNERABLE_IMAGE
 	EXTERNAL_INGRESS_CRITICAL_VULNERABILITY
 	UNLEASH_RELEASE_CHANNEL
+	RESTART_LOOP
 }
 
 type VulnerableImageIssue implements Issue & Node {
@@ -305,4 +306,19 @@ type UnleashReleaseChannelIssue implements Issue & Node {
 	majorVersion: Int!
 	"The current major version of Unleash available."
 	currentMajorVersion: Int!
+}
+
+type RestartLoopIssue implements Issue & Node {
+	id: ID!
+	teamEnvironment: TeamEnvironment!
+	severity: Severity!
+	message: String!
+
+	workload: Workload!
+	"The number of container restarts."
+	restartCount: Int!
+	"The reason for the last container exit."
+	lastExitReason: String!
+	"The timestamp of the last container exit."
+	lastExitTimestamp: Time!
 }

--- a/internal/issue/checker/workload.go
+++ b/internal/issue/checker/workload.go
@@ -46,6 +46,7 @@ func (w Workload) Run(ctx context.Context) ([]Issue, error) {
 		ret = appendIssues(ret, deprecatedIngress(app.Obj, env))
 		ret = appendIssues(ret, deprecatedRegistry(image, app.Obj.GetName(), app.Obj.GetNamespace(), env, issue.ResourceTypeApplication))
 		ret = appendIssues(ret, w.noRunningInstances(app.Obj, app.Obj.GetNamespace(), env))
+		ret = appendIssues(ret, w.restartLoop(app.Obj, app.Obj.GetNamespace(), env))
 		ret = appendIssues(ret, w.specErrors(app.Obj, env, issue.ResourceTypeApplication))
 	}
 

--- a/internal/issue/checker/workload_restartloop.go
+++ b/internal/issue/checker/workload_restartloop.go
@@ -1,0 +1,116 @@
+package checker
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/nais/api/internal/issue"
+	"github.com/nais/api/internal/kubernetes/watcher"
+	nais_io_v1alpha1 "github.com/nais/liberator/pkg/apis/nais.io/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+const (
+	restartLoopWarningMinRestarts  = 3
+	restartLoopCriticalMinRestarts = 10
+	restartLoopWarningWindow       = 30 * time.Minute
+	restartLoopCriticalWindow      = 10 * time.Minute
+)
+
+// restartLoop checks whether an application is stuck in a restart loop.
+// It returns a Warning issue if any pod has restarted ≥3 times within the last 30 minutes,
+// or a Critical issue if any pod has restarted ≥10 times within the last 10 minutes.
+func (w Workload) restartLoop(app *nais_io_v1alpha1.Application, team, env string) *Issue {
+	nameReq, err := labels.NewRequirement("app", selection.Equals, []string{app.Name})
+	if err != nil {
+		w.log.WithError(err).Error("create label requirement")
+		return nil
+	}
+
+	pods := w.PodWatcher.GetByNamespace(
+		team,
+		watcher.WithLabels(labels.NewSelector().Add(*nameReq)),
+		watcher.InCluster(env),
+	)
+
+	now := time.Now()
+
+	type candidate struct {
+		restartCount      int32
+		lastExitReason    string
+		lastExitTimestamp time.Time
+		severity          issue.Severity
+	}
+
+	var best *candidate
+
+	for _, pod := range watcher.Objects(pods) {
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name != app.Name {
+				continue
+			}
+			if cs.LastTerminationState.Terminated == nil {
+				continue
+			}
+
+			finishedAt := cs.LastTerminationState.Terminated.FinishedAt.Time
+			age := now.Sub(finishedAt)
+
+			var sev issue.Severity
+			switch {
+			case cs.RestartCount >= restartLoopCriticalMinRestarts && age <= restartLoopCriticalWindow:
+				sev = issue.SeverityCritical
+			case cs.RestartCount >= restartLoopWarningMinRestarts && age <= restartLoopWarningWindow:
+				sev = issue.SeverityWarning
+			default:
+				continue
+			}
+
+			c := &candidate{
+				restartCount:      cs.RestartCount,
+				lastExitReason:    cs.LastTerminationState.Terminated.Reason,
+				lastExitTimestamp: finishedAt,
+				severity:          sev,
+			}
+
+			if best == nil || c.restartCount > best.restartCount || (c.severity == issue.SeverityCritical && best.severity != issue.SeverityCritical) {
+				best = c
+			}
+		}
+	}
+
+	if best == nil {
+		return nil
+	}
+
+	age := now.Sub(best.lastExitTimestamp)
+	minutesAgo := int(age.Minutes())
+
+	var timeDesc string
+	switch {
+	case minutesAgo < 1:
+		timeDesc = "less than a minute ago"
+	case minutesAgo == 1:
+		timeDesc = "1 minute ago"
+	default:
+		timeDesc = fmt.Sprintf("%d minutes ago", minutesAgo)
+	}
+
+	message := fmt.Sprintf("Application has restarted %d times, most recently %s (%s)", best.restartCount, timeDesc, best.lastExitReason)
+
+	return &Issue{
+		IssueType:    issue.IssueTypeRestartLoop,
+		ResourceName: app.Name,
+		ResourceType: issue.ResourceTypeApplication,
+		Team:         team,
+		Env:          env,
+		Severity:     best.severity,
+		Message:      message,
+		IssueDetails: issue.RestartLoopIssueDetails{
+			RestartCount:      int(best.restartCount),
+			LastExitReason:    best.lastExitReason,
+			LastExitTimestamp: best.lastExitTimestamp,
+		},
+	}
+}

--- a/internal/issue/model.go
+++ b/internal/issue/model.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nais/api/internal/graph/ident"
 	"github.com/nais/api/internal/graph/model"
@@ -204,6 +205,7 @@ const (
 	IssueTypeMissingSBOM                          IssueType = "MISSING_SBOM"
 	IssueTypeExternalIngressCriticalVulnerability IssueType = "EXTERNAL_INGRESS_CRITICAL_VULNERABILITY"
 	IssueTypeUnleashReleaseChannel                IssueType = "UNLEASH_RELEASE_CHANNEL"
+	IssueTypeRestartLoop                          IssueType = "RESTART_LOOP"
 )
 
 var AllIssueType = []IssueType{
@@ -221,11 +223,12 @@ var AllIssueType = []IssueType{
 	IssueTypeMissingSBOM,
 	IssueTypeExternalIngressCriticalVulnerability,
 	IssueTypeUnleashReleaseChannel,
+	IssueTypeRestartLoop,
 }
 
 func (e IssueType) IsValid() bool {
 	switch e {
-	case IssueTypeOpenSearch, IssueTypeValkey, IssueTypeSqlInstanceState, IssueTypeSqlInstanceVersion, IssueTypeDeprecatedIngress, IssueTypeDeprecatedRegistry, IssueTypeNoRunningInstances, IssueTypeLastRunFailed, IssueTypeInvalidSpec, IssueTypeFailedSynchronization, IssueTypeVulnerableImage, IssueTypeMissingSBOM, IssueTypeExternalIngressCriticalVulnerability, IssueTypeUnleashReleaseChannel:
+	case IssueTypeOpenSearch, IssueTypeValkey, IssueTypeSqlInstanceState, IssueTypeSqlInstanceVersion, IssueTypeDeprecatedIngress, IssueTypeDeprecatedRegistry, IssueTypeNoRunningInstances, IssueTypeLastRunFailed, IssueTypeInvalidSpec, IssueTypeFailedSynchronization, IssueTypeVulnerableImage, IssueTypeMissingSBOM, IssueTypeExternalIngressCriticalVulnerability, IssueTypeUnleashReleaseChannel, IssueTypeRestartLoop:
 		return true
 	}
 	return false
@@ -422,3 +425,20 @@ type IssueFilter struct {
 
 	ResourceIssueFilter
 }
+
+// RestartLoopIssueDetails holds details about a restart loop issue.
+type RestartLoopIssueDetails struct {
+	RestartCount      int       `json:"restartCount"`
+	LastExitReason    string    `json:"lastExitReason"`
+	LastExitTimestamp time.Time `json:"lastExitTimestamp"`
+}
+
+// RestartLoopIssue is an issue raised when an application is stuck in a restart loop.
+type RestartLoopIssue struct {
+	Base
+	RestartLoopIssueDetails
+}
+
+func (RestartLoopIssue) IsIssue() {}
+
+func (RestartLoopIssue) IsNode() {}

--- a/internal/issue/queries.go
+++ b/internal/issue/queries.go
@@ -191,6 +191,15 @@ func convert(issue *issuesql.Issue) (Issue, error) {
 			Base:                              base,
 			UnleashReleaseChannelIssueDetails: *d,
 		}, nil
+	case IssueTypeRestartLoop:
+		d, err := unmarshal[RestartLoopIssueDetails](issue.IssueDetails)
+		if err != nil {
+			return nil, err
+		}
+		return &RestartLoopIssue{
+			Base:                    base,
+			RestartLoopIssueDetails: *d,
+		}, nil
 	}
 
 	return nil, fmt.Errorf("unknown issue type: %s", issue.IssueType)

--- a/internal/workload/application/models.go
+++ b/internal/workload/application/models.go
@@ -175,21 +175,22 @@ func terminatedMessage(t *corev1.ContainerStateTerminated) string {
 	return fmt.Sprintf("Instance exited with code %d.", t.ExitCode)
 }
 
-func (i *ApplicationInstance) lastTerminationInfo() (*string, *int) {
+func (i *ApplicationInstance) lastTerminationInfo() (*string, *int, *time.Time) {
 	last := i.ApplicationContainerStatus.LastTerminationState.Terminated
 	if last == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 	reason := last.Reason
 	exitCode := int(last.ExitCode)
 	if reason == "" {
 		reason = fmt.Sprintf("ExitCode:%d", exitCode)
 	}
-	return &reason, &exitCode
+	finishedAt := last.FinishedAt.Time
+	return &reason, &exitCode, &finishedAt
 }
 
 func (i *ApplicationInstance) Status() *ApplicationInstanceStatus {
-	lastExitReason, lastExitCode := i.lastTerminationInfo()
+	lastExitReason, lastExitCode, lastExitTimestamp := i.lastTerminationInfo()
 	ready := i.ApplicationContainerStatus.Ready
 
 	switch {
@@ -199,11 +200,12 @@ func (i *ApplicationInstance) Status() *ApplicationInstanceStatus {
 			msg = "Running, but not passing readiness check."
 		}
 		return &ApplicationInstanceStatus{
-			State:          ApplicationInstanceStateRunning,
-			Message:        msg,
-			Ready:          ready,
-			LastExitReason: lastExitReason,
-			LastExitCode:   lastExitCode,
+			State:             ApplicationInstanceStateRunning,
+			Message:           msg,
+			Ready:             ready,
+			LastExitReason:    lastExitReason,
+			LastExitCode:      lastExitCode,
+			LastExitTimestamp: lastExitTimestamp,
 		}
 
 	case i.ApplicationContainerStatus.State.Terminated != nil:
@@ -214,11 +216,12 @@ func (i *ApplicationInstance) Status() *ApplicationInstanceStatus {
 			state = ApplicationInstanceStateTerminated
 		}
 		return &ApplicationInstanceStatus{
-			State:          state,
-			Message:        msg,
-			Ready:          false,
-			LastExitReason: lastExitReason,
-			LastExitCode:   lastExitCode,
+			State:             state,
+			Message:           msg,
+			Ready:             false,
+			LastExitReason:    lastExitReason,
+			LastExitCode:      lastExitCode,
+			LastExitTimestamp: lastExitTimestamp,
 		}
 
 	case i.ApplicationContainerStatus.State.Waiting != nil:
@@ -228,20 +231,22 @@ func (i *ApplicationInstance) Status() *ApplicationInstanceStatus {
 			state = ApplicationInstanceStateStarting
 		}
 		return &ApplicationInstanceStatus{
-			State:          state,
-			Message:        msg,
-			Ready:          false,
-			LastExitReason: lastExitReason,
-			LastExitCode:   lastExitCode,
+			State:             state,
+			Message:           msg,
+			Ready:             false,
+			LastExitReason:    lastExitReason,
+			LastExitCode:      lastExitCode,
+			LastExitTimestamp: lastExitTimestamp,
 		}
 
 	default:
 		return &ApplicationInstanceStatus{
-			State:          ApplicationInstanceStateUnknown,
-			Message:        "Unknown state.",
-			Ready:          false,
-			LastExitReason: lastExitReason,
-			LastExitCode:   lastExitCode,
+			State:             ApplicationInstanceStateUnknown,
+			Message:           "Unknown state.",
+			Ready:             false,
+			LastExitReason:    lastExitReason,
+			LastExitCode:      lastExitCode,
+			LastExitTimestamp: lastExitTimestamp,
 		}
 	}
 }
@@ -617,11 +622,12 @@ type IngressMetrics struct {
 }
 
 type ApplicationInstanceStatus struct {
-	State          ApplicationInstanceState `json:"state"`
-	Message        string                   `json:"message"`
-	Ready          bool                     `json:"ready"`
-	LastExitReason *string                  `json:"lastExitReason,omitempty"`
-	LastExitCode   *int                     `json:"lastExitCode,omitempty"`
+	State             ApplicationInstanceState `json:"state"`
+	Message           string                   `json:"message"`
+	Ready             bool                     `json:"ready"`
+	LastExitReason    *string                  `json:"lastExitReason,omitempty"`
+	LastExitCode      *int                     `json:"lastExitCode,omitempty"`
+	LastExitTimestamp *time.Time               `json:"lastExitTimestamp,omitempty"`
 }
 
 type TeamApplicationsFilter struct {


### PR DESCRIPTION
## Summary

### Commit 1: `lastExitTimestamp` field on `ApplicationInstanceStatus`
- Added `lastExitTimestamp` field to the `ApplicationInstanceStatus` GraphQL type
- Sourced from `LastTerminationState.Terminated.FinishedAt` on the underlying Kubernetes container status
- Enables clients to know when a container last exited, which is essential for restart loop detection

### Commit 2: `RESTART_LOOP` issue checker for applications
- New `RESTART_LOOP` issue type that detects applications stuck in restart loops
- **Warning** threshold: ≥ 3 restarts within the last 30 minutes
- **Critical** threshold: ≥ 10 restarts within the last 10 minutes
- Issue metadata includes restart count, exit reason (e.g. `OOMKilled`, `Error`), and the last exit timestamp
- Integrated into the existing workload issue checker pipeline and exposed via the GraphQL issues API