### PR TITLE
Add NAIS source kind for instance group env vars

### DIFF
--- a/integration_tests/instance_groups.lua
+++ b/integration_tests/instance_groups.lua
@@ -175,12 +175,21 @@ Test.gql("Instance group with environment variables", function(t)
 								{
 									name = "myapp-abc123",
 									environmentVariables = {
-										-- Direct env var
+										-- Direct env var defined in Application CRD spec.env → SPEC
 										{
 											name = "APP_ENV",
 											value = "production",
 											source = {
 												kind = "SPEC",
+												name = "myapp",
+											},
+										},
+										-- Platform-injected env var (in pod spec but not in Application CRD spec.env) → NAIS
+										{
+											name = "NAIS_APP_NAME",
+											value = "myapp",
+											source = {
+												kind = "NAIS",
 												name = "myapp",
 											},
 										},

--- a/integration_tests/k8s_resources/instance_groups/dev/myteam/app.yaml
+++ b/integration_tests/k8s_resources/instance_groups/dev/myteam/app.yaml
@@ -7,6 +7,9 @@ spec:
   replicas:
     min: 2
     max: 4
+  env:
+    - name: APP_ENV
+      value: production
 
 ---
 apiVersion: apps/v1
@@ -61,6 +64,8 @@ spec:
           env:
             - name: APP_ENV
               value: production
+            - name: NAIS_APP_NAME
+              value: myapp
             - name: DB_HOST
               valueFrom:
                 configMapKeyRef:

--- a/internal/cmd/api/http.go
+++ b/internal/cmd/api/http.go
@@ -284,7 +284,7 @@ func ConfigureGraph(
 		ctx = workload.NewLoaderContext(ctx, watchers.PodWatcher)
 		ctx = secret.NewLoaderContext(ctx, watchers.SecretWatcher, secretClientCreator, dynamicClients, clusters, log)
 		ctx = config.NewLoaderContext(ctx, watchers.ConfigWatcher, log)
-		ctx = instancegroup.NewLoaderContext(ctx, watchers.ReplicaSetWatcher, watchers.PodWatcher, dynamicClients, log)
+		ctx = instancegroup.NewLoaderContext(ctx, watchers.ReplicaSetWatcher, watchers.PodWatcher, watchers.AppWatcher, dynamicClients, log)
 		ctx = aiven.NewLoaderContext(ctx, aivenProjects)
 		ctx = opensearch.NewLoaderContext(ctx, tenantName, watchers.OpenSearchWatcher, aivenClient, log)
 		ctx = valkey.NewLoaderContext(ctx, tenantName, watchers.ValkeyWatcher, aivenClient)

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -20643,9 +20643,14 @@ enum InstanceGroupValueSourceKind {
 	CONFIG
 
 	"""
-	The value is defined inline in the workload spec.
+	The value is defined inline in the workload spec (user-defined in nais.yaml).
 	"""
 	SPEC
+
+	"""
+	The value was injected by the Nais platform (naiserator), not defined by the user.
+	"""
+	NAIS
 }
 `, BuiltIn: false},
 	{Name: "../schema/issues.graphqls", Input: `extend type Team {

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -20643,7 +20643,7 @@ enum InstanceGroupValueSourceKind {
 	CONFIG
 
 	"""
-	The value is defined inline in the workload spec (user-defined in nais.yaml).
+	The value is defined inline in the workload's application manifest (user-defined).
 	"""
 	SPEC
 

--- a/internal/graph/schema/instancegroup.graphqls
+++ b/internal/graph/schema/instancegroup.graphqls
@@ -142,7 +142,7 @@ enum InstanceGroupValueSourceKind {
 	CONFIG
 
 	"""
-	The value is defined inline in the workload spec (user-defined in nais.yaml).
+	The value is defined inline in the workload's application manifest (user-defined).
 	"""
 	SPEC
 

--- a/internal/graph/schema/instancegroup.graphqls
+++ b/internal/graph/schema/instancegroup.graphqls
@@ -142,7 +142,12 @@ enum InstanceGroupValueSourceKind {
 	CONFIG
 
 	"""
-	The value is defined inline in the workload spec.
+	The value is defined inline in the workload spec (user-defined in nais.yaml).
 	"""
 	SPEC
+
+	"""
+	The value was injected by the Nais platform (naiserator), not defined by the user.
+	"""
+	NAIS
 }

--- a/internal/workload/instancegroup/dataloader.go
+++ b/internal/workload/instancegroup/dataloader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/nais/api/internal/environmentmapper"
 	"github.com/nais/api/internal/kubernetes/watcher"
+	nais_io_v1alpha1 "github.com/nais/liberator/pkg/apis/nais.io/v1alpha1"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,10 +19,11 @@ type ctxKey int
 
 const loadersKey ctxKey = iota
 
-func NewLoaderContext(ctx context.Context, rsWatcher *watcher.Watcher[*appsv1.ReplicaSet], podWatcher *watcher.Watcher[*corev1.Pod], k8sClients map[string]dynamic.Interface, log logrus.FieldLogger) context.Context {
+func NewLoaderContext(ctx context.Context, rsWatcher *watcher.Watcher[*appsv1.ReplicaSet], podWatcher *watcher.Watcher[*corev1.Pod], appWatcher *watcher.Watcher[*nais_io_v1alpha1.Application], k8sClients map[string]dynamic.Interface, log logrus.FieldLogger) context.Context {
 	return context.WithValue(ctx, loadersKey, &loaders{
 		rsWatcher:  rsWatcher,
 		podWatcher: podWatcher,
+		appWatcher: appWatcher,
 		k8sClients: k8sClients,
 		log:        log,
 	})
@@ -40,6 +42,7 @@ func fromContext(ctx context.Context) *loaders {
 type loaders struct {
 	rsWatcher  *watcher.Watcher[*appsv1.ReplicaSet]
 	podWatcher *watcher.Watcher[*corev1.Pod]
+	appWatcher *watcher.Watcher[*nais_io_v1alpha1.Application]
 	k8sClients map[string]dynamic.Interface
 	log        logrus.FieldLogger
 }

--- a/internal/workload/instancegroup/models.go
+++ b/internal/workload/instancegroup/models.go
@@ -81,12 +81,14 @@ const (
 	InstanceGroupValueSourceKindSecret InstanceGroupValueSourceKind = "SECRET"
 	InstanceGroupValueSourceKindConfig InstanceGroupValueSourceKind = "CONFIG"
 	InstanceGroupValueSourceKindSpec   InstanceGroupValueSourceKind = "SPEC"
+	InstanceGroupValueSourceKindNais   InstanceGroupValueSourceKind = "NAIS"
 )
 
 var AllInstanceGroupValueSourceKind = []InstanceGroupValueSourceKind{
 	InstanceGroupValueSourceKindSecret,
 	InstanceGroupValueSourceKindConfig,
 	InstanceGroupValueSourceKindSpec,
+	InstanceGroupValueSourceKindNais,
 }
 
 func (e InstanceGroupValueSourceKind) IsValid() bool {

--- a/internal/workload/instancegroup/queries.go
+++ b/internal/workload/instancegroup/queries.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nais/api/internal/slug"
 	"github.com/nais/api/internal/workload/application"
 	"github.com/nais/api/internal/workload/secret"
+	nais_io_v1alpha1 "github.com/nais/liberator/pkg/apis/nais.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -82,6 +83,9 @@ func ListEnvironmentVariables(ctx context.Context, ig *InstanceGroup) ([]*Instan
 	container := ig.PodTemplateSpec.Spec.Containers[0]
 	var envVars []*InstanceGroupEnvironmentVariable
 
+	app := getApplicationSpec(l, ig)
+	userEnvNames := userDefinedEnvNames(app)
+
 	// Direct env vars
 	for _, env := range container.Env {
 		ev := &InstanceGroupEnvironmentVariable{
@@ -114,21 +118,21 @@ func ListEnvironmentVariables(ctx context.Context, ig *InstanceGroup) ([]*Instan
 			value := "(" + env.ValueFrom.FieldRef.FieldPath + ")"
 			ev.Value = &value
 			ev.Source = InstanceGroupValueSource{
-				Kind: InstanceGroupValueSourceKindSpec,
+				Kind: InstanceGroupValueSourceKindNais,
 				Name: "fieldRef",
 			}
 		case env.ValueFrom != nil && env.ValueFrom.ResourceFieldRef != nil:
 			value := "(" + env.ValueFrom.ResourceFieldRef.Resource + ")"
 			ev.Value = &value
 			ev.Source = InstanceGroupValueSource{
-				Kind: InstanceGroupValueSourceKindSpec,
+				Kind: InstanceGroupValueSourceKindNais,
 				Name: "resourceFieldRef",
 			}
 		default:
 			value := env.Value
 			ev.Value = &value
 			ev.Source = InstanceGroupValueSource{
-				Kind: InstanceGroupValueSourceKindSpec,
+				Kind: specOrNais(env.Name, userEnvNames),
 				Name: ig.ApplicationName,
 			}
 		}
@@ -390,7 +394,7 @@ func expandProjectedVolume(ctx context.Context, l *loaders, ig *InstanceGroup, m
 	// subPath means a single file is mounted directly at mountPath
 	if mount.SubPath != "" {
 		// For projected volumes with subPath, use the first source as representative
-		source := InstanceGroupValueSource{Kind: InstanceGroupValueSourceKindSpec, Name: "projected"}
+		source := InstanceGroupValueSource{Kind: InstanceGroupValueSourceKindNais, Name: "projected"}
 		for _, src := range projected.Sources {
 			if src.Secret != nil {
 				source = InstanceGroupValueSource{Kind: InstanceGroupValueSourceKindSecret, Name: src.Secret.Name}
@@ -557,6 +561,43 @@ func getConfigMapFileContents(ctx context.Context, l *loaders, environmentName, 
 	}
 
 	return result, nil
+}
+
+// getApplicationSpec fetches the Application CRD for the given instance group, returning nil if not found.
+func getApplicationSpec(l *loaders, ig *InstanceGroup) *nais_io_v1alpha1.Application {
+	if l.appWatcher == nil {
+		return nil
+	}
+	app, err := l.appWatcher.Get(ig.EnvironmentName, ig.TeamSlug.String(), ig.ApplicationName)
+	if err != nil {
+		return nil
+	}
+	return app
+}
+
+// userDefinedEnvNames returns a set of env var names defined by the user in the Application CRD spec.
+func userDefinedEnvNames(app *nais_io_v1alpha1.Application) map[string]struct{} {
+	if app == nil {
+		return nil
+	}
+	names := make(map[string]struct{}, len(app.Spec.Env))
+	for _, e := range app.Spec.Env {
+		names[e.Name] = struct{}{}
+	}
+	return names
+}
+
+// specOrNais returns SPEC if the name is in the user-defined set, otherwise NAIS.
+// If the user-defined set is nil (Application CRD not found), returns NAIS — we cannot
+// confirm the user defined it, so we default to the platform-injected classification.
+func specOrNais(name string, userDefined map[string]struct{}) InstanceGroupValueSourceKind {
+	if userDefined == nil {
+		return InstanceGroupValueSourceKindNais
+	}
+	if _, ok := userDefined[name]; ok {
+		return InstanceGroupValueSourceKindSpec
+	}
+	return InstanceGroupValueSourceKindNais
 }
 
 func secretResource(client dynamic.Interface) dynamic.NamespaceableResourceInterface {

--- a/internal/workload/instancegroup/queries_test.go
+++ b/internal/workload/instancegroup/queries_test.go
@@ -1,0 +1,226 @@
+package instancegroup
+
+import (
+	"context"
+	"testing"
+
+	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
+	nais_io_v1alpha1 "github.com/nais/liberator/pkg/apis/nais.io/v1alpha1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// makeIG creates a minimal InstanceGroup for testing.
+func makeIG(appName string, envVars []corev1.EnvVar) *InstanceGroup {
+	return &InstanceGroup{
+		ApplicationName: appName,
+		TeamSlug:        "my-team",
+		EnvironmentName: "dev",
+		PodTemplateSpec: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: appName,
+						Env:  envVars,
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestSpecOrNais verifies the specOrNais helper function.
+func TestSpecOrNais(t *testing.T) {
+	tests := []struct {
+		name        string
+		envName     string
+		userDefined map[string]struct{}
+		want        InstanceGroupValueSourceKind
+	}{
+		{
+			name:        "name in user-defined set returns SPEC",
+			envName:     "MY_VAR",
+			userDefined: map[string]struct{}{"MY_VAR": {}},
+			want:        InstanceGroupValueSourceKindSpec,
+		},
+		{
+			name:        "name not in user-defined set returns NAIS",
+			envName:     "INJECTED_VAR",
+			userDefined: map[string]struct{}{"MY_VAR": {}},
+			want:        InstanceGroupValueSourceKindNais,
+		},
+		{
+			name:        "nil user-defined set (Application CRD not found) returns NAIS",
+			envName:     "ANY_VAR",
+			userDefined: nil,
+			want:        InstanceGroupValueSourceKindNais,
+		},
+		{
+			name:        "empty user-defined set returns NAIS",
+			envName:     "ANY_VAR",
+			userDefined: map[string]struct{}{},
+			want:        InstanceGroupValueSourceKindNais,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := specOrNais(tt.envName, tt.userDefined)
+			if got != tt.want {
+				t.Errorf("specOrNais(%q, ...) = %v, want %v", tt.envName, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestUserDefinedEnvNames verifies extraction of env var names from Application CRD.
+func TestUserDefinedEnvNames(t *testing.T) {
+	app := &nais_io_v1alpha1.Application{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "my-team"},
+		Spec: nais_io_v1alpha1.ApplicationSpec{
+			Env: nais_io_v1.EnvVars{
+				{Name: "MY_VAR", Value: "hello"},
+				{Name: "OTHER_VAR", Value: "world"},
+			},
+		},
+	}
+
+	names := userDefinedEnvNames(app)
+
+	if _, ok := names["MY_VAR"]; !ok {
+		t.Error("expected MY_VAR in user-defined env names")
+	}
+	if _, ok := names["OTHER_VAR"]; !ok {
+		t.Error("expected OTHER_VAR in user-defined env names")
+	}
+	if _, ok := names["INJECTED"]; ok {
+		t.Error("did not expect INJECTED in user-defined env names")
+	}
+}
+
+// TestUserDefinedEnvNamesNilApp verifies nil Application returns nil map.
+func TestUserDefinedEnvNamesNilApp(t *testing.T) {
+	names := userDefinedEnvNames(nil)
+	if names != nil {
+		t.Errorf("expected nil for nil app, got %v", names)
+	}
+}
+
+// TestFieldRefAndResourceFieldRefAlwaysNais verifies that fieldRef and resourceFieldRef
+// env vars are always classified as NAIS regardless of Application CRD.
+func TestFieldRefAndResourceFieldRefAlwaysNais(t *testing.T) {
+	fieldPath := "metadata.name"
+	resource := "limits.cpu"
+
+	envVars := []corev1.EnvVar{
+		{
+			Name: "POD_NAME",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{FieldPath: fieldPath},
+			},
+		},
+		{
+			Name: "CPU_LIMIT",
+			ValueFrom: &corev1.EnvVarSource{
+				ResourceFieldRef: &corev1.ResourceFieldSelector{Resource: resource},
+			},
+		},
+	}
+
+	ig := makeIG("my-app", envVars)
+
+	// Use a loaders with a nil appWatcher - fieldRef/resourceFieldRef should always be NAIS.
+	l := &loaders{
+		log: logrus.New(),
+	}
+	ctx := context.WithValue(context.Background(), loadersKey, l)
+
+	result, err := ListEnvironmentVariables(ctx, ig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 env vars, got %d", len(result))
+	}
+
+	for _, ev := range result {
+		if ev.Source.Kind != InstanceGroupValueSourceKindNais {
+			t.Errorf("env var %q: expected NAIS source kind, got %v", ev.Name, ev.Source.Kind)
+		}
+	}
+
+	if result[0].Name != "POD_NAME" {
+		t.Errorf("expected POD_NAME, got %s", result[0].Name)
+	}
+	if result[1].Name != "CPU_LIMIT" {
+		t.Errorf("expected CPU_LIMIT, got %s", result[1].Name)
+	}
+}
+
+// TestProjectedVolumeSubPathFallbackIsNais verifies that projected volumes with subPath
+// that have no secret/configmap source are classified as NAIS (not SPEC).
+func TestProjectedVolumeSubPathFallbackIsNais(t *testing.T) {
+	projected := &corev1.ProjectedVolumeSource{
+		Sources: []corev1.VolumeProjection{
+			// No secret or configmap - only service account token
+			{
+				ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+					Path: "token",
+				},
+			},
+		},
+	}
+
+	mount := corev1.VolumeMount{
+		MountPath: "/var/run/secrets/token",
+		SubPath:   "token",
+	}
+
+	l := &loaders{log: logrus.New()}
+	ig := &InstanceGroup{ApplicationName: "my-app", TeamSlug: "my-team", EnvironmentName: "dev"}
+
+	files := expandProjectedVolume(context.Background(), l, ig, mount, projected)
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+
+	if files[0].Source.Kind != InstanceGroupValueSourceKindNais {
+		t.Errorf("expected NAIS source kind for projected volume fallback, got %v", files[0].Source.Kind)
+	}
+	if files[0].Source.Name != "projected" {
+		t.Errorf("expected source name 'projected', got %q", files[0].Source.Name)
+	}
+}
+
+// TestInlineEnvVarClassificationWithNilAppWatcher verifies that when the Application CRD
+// cannot be found (nil appWatcher), inline env vars are classified as NAIS — we cannot
+// confirm the user defined them, so we default to the platform-injected classification.
+func TestInlineEnvVarClassificationWithNilAppWatcher(t *testing.T) {
+	envVars := []corev1.EnvVar{
+		{Name: "SOME_VAR", Value: "value"},
+	}
+
+	ig := makeIG("my-app", envVars)
+
+	// nil appWatcher means getApplicationSpec returns nil, which means specOrNais returns NAIS
+	l := &loaders{
+		log: logrus.New(),
+	}
+	ctx := context.WithValue(context.Background(), loadersKey, l)
+
+	result, err := ListEnvironmentVariables(ctx, ig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(result))
+	}
+
+	if result[0].Source.Kind != InstanceGroupValueSourceKindNais {
+		t.Errorf("expected NAIS when Application CRD not found, got %v", result[0].Source.Kind)
+	}
+}


### PR DESCRIPTION
## Summary

- Splits `SPEC` in `InstanceGroupValueSourceKind` into `SPEC` (user-defined in `.spec.env`) and `NAIS` (platform-injected by naiserator)
- Looks up the Application CRD via `AppWatcher` to determine which inline env vars the user actually defined
- `fieldRef`/`resourceFieldRef` and projected volume subPath fallback are always classified as `NAIS`
- Falls back to `NAIS` when Application CRD is not found (conservative default)

This makes it easier for CLI and Console to distinguish platform-injected values from user-defined ones without client-side heuristics.