### PR TITLE
Improve startup by logging unsynced caches and not failing on timeout

### DIFF
--- a/internal/cmd/api/http.go
+++ b/internal/cmd/api/http.go
@@ -316,24 +316,20 @@ func ConfigureGraph(
 		costOpts = append(costOpts, cost.WithClient(cost.NewFakeClient()))
 	}
 
-	syncCtx, cancelSync := context.WithTimeout(ctx, 20*time.Second)
+	syncCtx, cancelSync := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancelSync()
-	if err := logStep("watcherMgr.WaitForReady", func() error {
+	_ = logStep("watcherMgr.WaitForReady", func() error {
 		if !watcherMgr.WaitForReady(syncCtx) {
-			return errors.New("timed out waiting for watchers to be ready")
+			log.Warn("timed out waiting for watchers to be ready; continuing startup, /readyz will report not-ready until caches sync")
 		}
 		return nil
-	}); err != nil {
-		return nil, err
-	}
-	if err := logStep("mgmtWatcherMgr.WaitForReady", func() error {
+	})
+	_ = logStep("mgmtWatcherMgr.WaitForReady", func() error {
 		if !mgmtWatcherMgr.WaitForReady(syncCtx) {
-			return errors.New("timed out waiting for management watchers to be ready")
+			log.Warn("timed out waiting for management watchers to be ready; continuing startup, /readyz will report not-ready until caches sync")
 		}
 		return nil
-	}); err != nil {
-		return nil, err
-	}
+	})
 
 	setupContext := func(ctx context.Context) context.Context {
 		ctx = podlog.NewLoaderContext(ctx, podLogStreamer)

--- a/internal/kubernetes/watcher/manager.go
+++ b/internal/kubernetes/watcher/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
+	"time"
 
 	"github.com/nais/api/internal/kubernetes"
 	"github.com/sirupsen/logrus"
@@ -20,6 +21,12 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/cache"
 )
+
+type cacheSyncEntry struct {
+	cluster string
+	gvr     string
+	synced  cache.InformerSynced
+}
 
 type settings struct {
 	clientCreator func(cluster string) (dynamic.Interface, KindResolver, *rest.Config, error)
@@ -43,6 +50,7 @@ type Manager struct {
 	log      logrus.FieldLogger
 
 	cacheSyncs      []cache.InformerSynced
+	cacheSyncInfo   []cacheSyncEntry
 	ready           atomic.Bool
 	resourceCounter metric.Int64UpDownCounter
 }
@@ -126,17 +134,56 @@ func (m *Manager) Stop() {
 }
 
 func (m *Manager) WaitForReady(ctx context.Context) bool {
-	ok := cache.WaitForCacheSync(ctx.Done(), m.cacheSyncs...)
-	if ok {
-		m.ready.Store(true)
+	doneCh := make(chan bool, 1)
+	go func() {
+		doneCh <- cache.WaitForCacheSync(ctx.Done(), m.cacheSyncs...)
+	}()
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case ok := <-doneCh:
+			if ok {
+				m.ready.Store(true)
+			} else {
+				m.logUnsynced("cache sync failed/cancelled, still unsynced")
+			}
+			return ok
+		case <-ticker.C:
+			m.logUnsynced("still waiting for cache sync")
+		}
 	}
-	return ok
+}
+
+func (m *Manager) logUnsynced(msg string) {
+	for _, e := range m.cacheSyncInfo {
+		if !e.synced() {
+			m.log.WithFields(logrus.Fields{
+				"cluster": e.cluster,
+				"gvr":     e.gvr,
+			}).Warn(msg)
+		}
+	}
 }
 
 // IsReady returns true if all informer caches have been synced.
-// This is a non-blocking check that returns the result of the last WaitForReady call.
+// This is a non-blocking check that inspects the current state of every
+// registered informer, so it will start reporting true as soon as the last
+// outstanding cache finishes syncing — even if the initial WaitForReady call
+// timed out.
 func (m *Manager) IsReady() bool {
-	return m.ready.Load()
+	if m.ready.Load() {
+		return true
+	}
+	for _, e := range m.cacheSyncInfo {
+		if !e.synced() {
+			return false
+		}
+	}
+	m.ready.Store(true)
+	return true
 }
 
 func (m *Manager) GetDynamicClients() map[string]dynamic.Interface {
@@ -157,8 +204,13 @@ func (m *Manager) ResourceMappers() map[string]KindResolver {
 	return clients
 }
 
-func (m *Manager) addCacheSync(sync cache.InformerSynced) {
+func (m *Manager) addCacheSync(cluster, gvr string, sync cache.InformerSynced) {
 	m.cacheSyncs = append(m.cacheSyncs, sync)
+	m.cacheSyncInfo = append(m.cacheSyncInfo, cacheSyncEntry{
+		cluster: cluster,
+		gvr:     gvr,
+		synced:  sync,
+	})
 }
 
 func Watch[T Object](mgr *Manager, obj T, opts ...WatchOption) *Watcher[T] {

--- a/internal/kubernetes/watcher/watcher.go
+++ b/internal/kubernetes/watcher/watcher.go
@@ -77,7 +77,7 @@ func newWatcher[T Object](mgr *Manager, obj T, settings *watcherSettings, log lo
 		w.watchedType = gvr.String()
 
 		w.watchers = append(w.watchers, watcher)
-		mgr.addCacheSync(watcher.informer.Informer().HasSynced)
+		mgr.addCacheSync(cluster, gvr.String(), watcher.informer.Informer().HasSynced)
 	}
 	return w
 }


### PR DESCRIPTION
- Increase cache sync timeout to 2 minutes
- Log unsynced clusters/resources every 10s while waiting
- Continue startup if caches are not synced; /readyz will report not-ready
- Track cache sync state per cluster/resource for better diagnostics