### PR TITLE
fix: prevent open redirect in OAuth callback via protocol-relative URLs

### DIFF
--- a/internal/auth/authn/handler.go
+++ b/internal/auth/authn/handler.go
@@ -54,9 +54,19 @@ type claims struct {
 	Email string
 }
 
+// isSafeRedirectPath returns true if the path is a safe relative path that cannot
+// be used to redirect users to an external site (e.g. //attacker.com).
+func isSafeRedirectPath(path string) bool {
+	u, err := url.Parse(path)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "" && u.Host == "" && strings.HasPrefix(u.Path, "/")
+}
+
 func (h *handler) Login(w http.ResponseWriter, r *http.Request) {
 	redirectURI := r.URL.Query().Get("redirect_uri")
-	if len(redirectURI) > 0 && strings.HasPrefix(redirectURI, "/") {
+	if len(redirectURI) > 0 && isSafeRedirectPath(redirectURI) {
 		http.SetCookie(w, &http.Cookie{
 			Name:     RedirectURICookie,
 			Value:    redirectURI,
@@ -96,7 +106,10 @@ func (h *handler) Callback(w http.ResponseWriter, r *http.Request) {
 	redirectURIRaw, err := r.Cookie(RedirectURICookie)
 	if err == nil {
 		if redirectPath, err := url.QueryUnescape(redirectURIRaw.Value); err == nil {
-			frontendURL = redirectPath
+			// Re-validate after unescaping to prevent open redirect via encoded payloads.
+			if isSafeRedirectPath(redirectPath) {
+				frontendURL = redirectPath
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

The OAuth callback handler reads a `redirect_uri` cookie and redirects the user to that path after a successful login. The value is stored in `Login()` with a `strings.HasPrefix(redirectURI, "/")` check, then URL-decoded in `Callback()` before use — but **never re-validated after decoding**.

An attacker can bypass the prefix check with a protocol-relative URL:

```
GET /oauth2/login?redirect_uri=//attacker.com
```

`//attacker.com` passes `strings.HasPrefix("/")` ✓ and gets stored in the cookie.  
In `Callback`, `url.QueryUnescape("//attacker.com")` returns `//attacker.com`, which `http.Redirect` resolves as `https://attacker.com` — sending the user (and their browser) off-site.

## Fix

Introduce `isSafeRedirectPath()` that uses `url.Parse` to assert the redirect target has no `Scheme` or `Host` component, making it strictly relative. Apply this check both on write (`Login`) and on read (`Callback`).

```go
func isSafeRedirectPath(path string) bool {
    u, err := url.Parse(path)
    if err != nil {
        return false
    }
    return u.Scheme == "" && u.Host == "" && strings.HasPrefix(u.Path, "/")
}
```

## Security impact

- **Type:** Open Redirect (CWE-601)
- **Severity:** High
- **Exploitability:** Any unauthenticated user; no credentials required
- **Impact:** Post-login phishing; credential/session theft via attacker-controlled landing page