### PR TITLE
Add haproxy ingress classes to ingress class mapping

### DIFF
--- a/internal/workload/application/ingress_class_mapping.go
+++ b/internal/workload/application/ingress_class_mapping.go
@@ -4,4 +4,7 @@ var ingressClassMapping = map[string]IngressType{
 	"nais-ingress":          IngressTypeInternal,
 	"nais-ingress-external": IngressTypeExternal,
 	"nais-ingress-fa":       IngressTypeAuthenticated,
+	"internal-haproxy":      IngressTypeInternal,
+	"external-haproxy":      IngressTypeExternal,
+	"external-fa-haproxy":   IngressTypeAuthenticated,
 }


### PR DESCRIPTION
Adds `internal-haproxy`, `external-haproxy`, and `external-fa-haproxy` to the ingress class mapping.

Without this, ingresses using haproxy ingress classes are reported as `UNKNOWN` type in the API because `GetIngressType` only recognized `nais-ingress`, `nais-ingress-external`, and `nais-ingress-fa`.