### PR TITLE
Implement Node interface on InstanceGroupEnvironmentVariable

### DIFF
--- a/internal/graph/gengql/instancegroup.generated.go
+++ b/internal/graph/gengql/instancegroup.generated.go
@@ -282,6 +282,29 @@ func (ec *executionContext) fieldContext_InstanceGroup_instances(_ context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _InstanceGroupEnvironmentVariable_id(ctx context.Context, field graphql.CollectedField, obj *instancegroup.InstanceGroupEnvironmentVariable) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_InstanceGroupEnvironmentVariable_id(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ID(), nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v ident.Ident) graphql.Marshaler {
+			return ec.marshalNID2githubᚗcomᚋnaisᚋapiᚋinternalᚋgraphᚋidentᚐIdent(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_InstanceGroupEnvironmentVariable_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("InstanceGroupEnvironmentVariable", field, true, false, errors.New("field of type ID does not have child fields"))
+}
+
 func (ec *executionContext) _InstanceGroupEnvironmentVariable_name(ctx context.Context, field graphql.CollectedField, obj *instancegroup.InstanceGroupEnvironmentVariable) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -714,7 +737,7 @@ func (ec *executionContext) _InstanceGroup(ctx context.Context, sel ast.Selectio
 	return out
 }
 
-var instanceGroupEnvironmentVariableImplementors = []string{"InstanceGroupEnvironmentVariable"}
+var instanceGroupEnvironmentVariableImplementors = []string{"InstanceGroupEnvironmentVariable", "Node"}
 
 func (ec *executionContext) _InstanceGroupEnvironmentVariable(ctx context.Context, sel ast.SelectionSet, obj *instancegroup.InstanceGroupEnvironmentVariable) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, instanceGroupEnvironmentVariableImplementors)
@@ -725,6 +748,11 @@ func (ec *executionContext) _InstanceGroupEnvironmentVariable(ctx context.Contex
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("InstanceGroupEnvironmentVariable")
+		case "id":
+			out.Values[i] = ec._InstanceGroupEnvironmentVariable_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "name":
 			out.Values[i] = ec._InstanceGroupEnvironmentVariable_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -1014,6 +1014,7 @@ type ComplexityRoot struct {
 	}
 
 	InstanceGroupEnvironmentVariable struct {
+		ID     func(childComplexity int) int
 		Name   func(childComplexity int) int
 		Source func(childComplexity int) int
 		Value  func(childComplexity int) int
@@ -6847,6 +6848,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.InstanceGroup.ReadyInstances(childComplexity), true
+
+	case "InstanceGroupEnvironmentVariable.id":
+		if e.ComplexityRoot.InstanceGroupEnvironmentVariable.ID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.InstanceGroupEnvironmentVariable.ID(childComplexity), true
 
 	case "InstanceGroupEnvironmentVariable.name":
 		if e.ComplexityRoot.InstanceGroupEnvironmentVariable.Name == nil {
@@ -21087,7 +21095,12 @@ type InstanceGroup implements Node {
 """
 An environment variable configured for an instance group.
 """
-type InstanceGroupEnvironmentVariable {
+type InstanceGroupEnvironmentVariable implements Node {
+	"""
+	The globally unique ID of the environment variable.
+	"""
+	id: ID!
+
 	"""
 	The name of the environment variable.
 	"""
@@ -31043,6 +31056,8 @@ func (ec *executionContext) childFields_InstanceGroup(ctx context.Context, field
 
 func (ec *executionContext) childFields_InstanceGroupEnvironmentVariable(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
+	case "id":
+		return ec.fieldContext_InstanceGroupEnvironmentVariable_id(ctx, field)
 	case "name":
 		return ec.fieldContext_InstanceGroupEnvironmentVariable_name(ctx, field)
 	case "value":

--- a/internal/graph/gengql/schema.generated.go
+++ b/internal/graph/gengql/schema.generated.go
@@ -6368,6 +6368,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._Issue(ctx, sel, obj)
+	case instancegroup.InstanceGroupEnvironmentVariable:
+		return ec._InstanceGroupEnvironmentVariable(ctx, sel, &obj)
+	case *instancegroup.InstanceGroupEnvironmentVariable:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._InstanceGroupEnvironmentVariable(ctx, sel, obj)
 	case instancegroup.InstanceGroup:
 		return ec._InstanceGroup(ctx, sel, &obj)
 	case *instancegroup.InstanceGroup:

--- a/internal/graph/schema/instancegroup.graphqls
+++ b/internal/graph/schema/instancegroup.graphqls
@@ -61,7 +61,12 @@ type InstanceGroup implements Node {
 """
 An environment variable configured for an instance group.
 """
-type InstanceGroupEnvironmentVariable {
+type InstanceGroupEnvironmentVariable implements Node {
+	"""
+	The globally unique ID of the environment variable.
+	"""
+	id: ID!
+
 	"""
 	The name of the environment variable.
 	"""

--- a/internal/workload/instancegroup/models.go
+++ b/internal/workload/instancegroup/models.go
@@ -52,6 +52,17 @@ type InstanceGroupEnvironmentVariable struct {
 	Name   string                   `json:"name"`
 	Value  *string                  `json:"value"`
 	Source InstanceGroupValueSource `json:"source"`
+
+	TeamSlug          slug.Slug `json:"-"`
+	EnvironmentName   string    `json:"-"`
+	ApplicationName   string    `json:"-"`
+	InstanceGroupName string    `json:"-"`
+}
+
+func (InstanceGroupEnvironmentVariable) IsNode() {}
+
+func (ev InstanceGroupEnvironmentVariable) ID() ident.Ident {
+	return newEnvVarIdent(ev.TeamSlug, ev.EnvironmentName, ev.ApplicationName, ev.InstanceGroupName, ev.Name)
 }
 
 // InstanceGroupMountedFile represents a file mounted from a Secret or ConfigMap.

--- a/internal/workload/instancegroup/node.go
+++ b/internal/workload/instancegroup/node.go
@@ -9,14 +9,22 @@ import (
 
 type identType int
 
-const identKey identType = iota
+const (
+	identKey    identType = iota
+	identKeyEnv identType = iota
+)
 
 func init() {
 	ident.RegisterIdentType(identKey, "IG", GetByIdent)
+	ident.RegisterIdentType(identKeyEnv, "IGEV", GetEnvironmentVariableByIdent)
 }
 
 func newIdent(teamSlug slug.Slug, environment, applicationName, instanceGroupName string) ident.Ident {
 	return ident.NewIdent(identKey, teamSlug.String(), environment, applicationName, instanceGroupName)
+}
+
+func newEnvVarIdent(teamSlug slug.Slug, environment, applicationName, instanceGroupName, envVarName string) ident.Ident {
+	return ident.NewIdent(identKeyEnv, teamSlug.String(), environment, applicationName, instanceGroupName, envVarName)
 }
 
 func parseIdent(id ident.Ident) (teamSlug slug.Slug, environment, applicationName, instanceGroupName string, err error) {
@@ -26,4 +34,13 @@ func parseIdent(id ident.Ident) (teamSlug slug.Slug, environment, applicationNam
 	}
 
 	return slug.Slug(parts[0]), parts[1], parts[2], parts[3], nil
+}
+
+func parseEnvVarIdent(id ident.Ident) (teamSlug slug.Slug, environment, applicationName, instanceGroupName, envVarName string, err error) {
+	parts := id.Parts()
+	if len(parts) != 5 {
+		return "", "", "", "", "", fmt.Errorf("invalid instance group environment variable ident")
+	}
+
+	return slug.Slug(parts[0]), parts[1], parts[2], parts[3], parts[4], nil
 }

--- a/internal/workload/instancegroup/queries.go
+++ b/internal/workload/instancegroup/queries.go
@@ -71,6 +71,38 @@ func GetByIdent(ctx context.Context, id ident.Ident) (*InstanceGroup, error) {
 	return toGraphInstanceGroup(rs, env), nil
 }
 
+// GetEnvironmentVariableByIdent returns an environment variable by its ident.
+func GetEnvironmentVariableByIdent(ctx context.Context, id ident.Ident) (*InstanceGroupEnvironmentVariable, error) {
+	teamSlug, env, appName, igName, envVarName, err := parseEnvVarIdent(id)
+	if err != nil {
+		return nil, err
+	}
+
+	l := fromContext(ctx)
+	rs, err := l.rsWatcher.Get(env, teamSlug.String(), igName)
+	if err != nil {
+		return nil, err
+	}
+
+	ig := toGraphInstanceGroup(rs, env)
+	if ig.ApplicationName != appName {
+		return nil, fmt.Errorf("instance group %q does not belong to application %q", igName, appName)
+	}
+
+	envVars, err := ListEnvironmentVariables(ctx, ig)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ev := range envVars {
+		if ev.Name == envVarName {
+			return ev, nil
+		}
+	}
+
+	return nil, fmt.Errorf("environment variable %q not found in instance group %q", envVarName, igName)
+}
+
 // ListEnvironmentVariables extracts environment variables from the instance group's pod template.
 // For envFrom references, it resolves individual key names by querying the Kubernetes API.
 // Variables from Secrets have nil values (require elevation). Variables from ConfigMaps include values.
@@ -89,7 +121,11 @@ func ListEnvironmentVariables(ctx context.Context, ig *InstanceGroup) ([]*Instan
 	// Direct env vars
 	for _, env := range container.Env {
 		ev := &InstanceGroupEnvironmentVariable{
-			Name: env.Name,
+			Name:              env.Name,
+			TeamSlug:          ig.TeamSlug,
+			EnvironmentName:   ig.EnvironmentName,
+			ApplicationName:   ig.ApplicationName,
+			InstanceGroupName: ig.Name,
 		}
 
 		switch {
@@ -156,6 +192,10 @@ func ListEnvironmentVariables(ctx context.Context, ig *InstanceGroup) ([]*Instan
 						Kind: InstanceGroupValueSourceKindSecret,
 						Name: secretName,
 					},
+					TeamSlug:          ig.TeamSlug,
+					EnvironmentName:   ig.EnvironmentName,
+					ApplicationName:   ig.ApplicationName,
+					InstanceGroupName: ig.Name,
 				})
 				continue
 			}
@@ -166,6 +206,10 @@ func ListEnvironmentVariables(ctx context.Context, ig *InstanceGroup) ([]*Instan
 						Kind: InstanceGroupValueSourceKindSecret,
 						Name: secretName,
 					},
+					TeamSlug:          ig.TeamSlug,
+					EnvironmentName:   ig.EnvironmentName,
+					ApplicationName:   ig.ApplicationName,
+					InstanceGroupName: ig.Name,
 				})
 			}
 
@@ -180,6 +224,10 @@ func ListEnvironmentVariables(ctx context.Context, ig *InstanceGroup) ([]*Instan
 						Kind: InstanceGroupValueSourceKindConfig,
 						Name: cmName,
 					},
+					TeamSlug:          ig.TeamSlug,
+					EnvironmentName:   ig.EnvironmentName,
+					ApplicationName:   ig.ApplicationName,
+					InstanceGroupName: ig.Name,
 				})
 				continue
 			}
@@ -192,6 +240,10 @@ func ListEnvironmentVariables(ctx context.Context, ig *InstanceGroup) ([]*Instan
 						Kind: InstanceGroupValueSourceKindConfig,
 						Name: cmName,
 					},
+					TeamSlug:          ig.TeamSlug,
+					EnvironmentName:   ig.EnvironmentName,
+					ApplicationName:   ig.ApplicationName,
+					InstanceGroupName: ig.Name,
 				})
 			}
 		}


### PR DESCRIPTION
## Summary

- Adds `id: ID!` field and `implements Node` to `InstanceGroupEnvironmentVariable` in the GraphQL schema
- Registers a new ident type (`IGEV`) with 5 parts (team, env, app, instance group, env var name)
- Implements `GetEnvironmentVariableByIdent` for global node lookup
- Populates parent context fields on all constructed env var instances