### PR TITLE
Fix ServiceAccountHasTeamMembership strict check and add integration

### DIFF
--- a/integration_tests/serviceaccount_strict_auth.lua
+++ b/integration_tests/serviceaccount_strict_auth.lua
@@ -1,0 +1,180 @@
+Helper.readK8sResources("k8s_resources/secrets")
+
+-- Create a user who will own the team and set up the secret
+local owner = User.new("sa-owner", "sa-owner@example.com", "ext-sa-owner")
+local team = Team.new("myteam", "Team for SA strict auth test", "#sa-test")
+team:addOwner(owner)
+
+-- Create a second team for cross-team tests
+local otherTeam = Team.new("otherteam", "Other team", "#other")
+
+-- Create a team-scoped service account with "Team member" role
+local sa = ServiceAccount.new("strict-auth-sa", "myteam")
+sa:assignRole("Team member")
+
+-- Create a cross-team service account (belongs to otherteam)
+local crossTeamSa = ServiceAccount.new("cross-team-sa", "otherteam")
+crossTeamSa:assignRole("Team member")
+
+-- Create a global service account (no team)
+local globalSa = ServiceAccount.new("global-sa")
+globalSa:assignRole("Team member")
+
+-- Owner creates a secret with a value to test reading
+Test.gql("Owner creates secret with value", function(t)
+	t.addHeader("x-user-email", owner:email())
+
+	t.query [[
+		mutation {
+			createSecret(input: {
+				name: "sa-test-secret"
+				environment: "dev"
+				team: "myteam"
+			}) {
+				secret {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			createSecret = {
+				secret = {
+					name = "sa-test-secret",
+				},
+			},
+		},
+	}
+
+	t.query [[
+		mutation {
+			addSecretValue(input: {
+				name: "sa-test-secret"
+				environment: "dev"
+				team: "myteam"
+				value: {
+					name: "MY_KEY"
+					value: "my-secret-value"
+				}
+			}) {
+				secret {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			addSecretValue = {
+				secret = {
+					name = "sa-test-secret",
+				},
+			},
+		},
+	}
+end)
+
+-- Service account should be able to read secret values.
+-- This uses requireStrictTeamAuthorization (CanReadSecretValues),
+-- which was broken before the ServiceAccountHasTeamMembership fix.
+Test.gql("Service account CAN read secret values (strict auth)", function(t)
+	t.addHeader("Authorization", "Bearer " .. sa:token())
+
+	t.query [[
+		mutation {
+			viewSecretValues(input: {
+				name: "sa-test-secret"
+				environment: "dev"
+				team: "myteam"
+				reason: "Service account reading secret values for automation"
+			}) {
+				values {
+					name
+					value
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			viewSecretValues = {
+				values = {
+					{
+						name = "MY_KEY",
+						value = "my-secret-value",
+					},
+				},
+			},
+		},
+	}
+end)
+
+-- A service account scoped to a DIFFERENT team should NOT be able
+-- to read secrets, even with "Team member" role.
+-- This verifies that the strict check enforces team_slug matching.
+Test.gql("Cross-team SA CANNOT read secret values (strict auth)", function(t)
+	t.addHeader("Authorization", "Bearer " .. crossTeamSa:token())
+
+	t.query [[
+		mutation {
+			viewSecretValues(input: {
+				name: "sa-test-secret"
+				environment: "dev"
+				team: "myteam"
+				reason: "Cross-team SA trying to read secrets from another team"
+			}) {
+				values {
+					name
+					value
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = Null,
+		errors = {
+			{
+				locations = NotNull(),
+				message = Contains("You are authenticated"),
+				path = { "viewSecretValues" },
+			},
+		},
+	}
+end)
+
+-- A global service account (no team) should also NOT pass strict checks.
+Test.gql("Global SA CANNOT read secret values (strict auth rejects global)", function(t)
+	t.addHeader("Authorization", "Bearer " .. globalSa:token())
+
+	t.query [[
+		mutation {
+			viewSecretValues(input: {
+				name: "sa-test-secret"
+				environment: "dev"
+				team: "myteam"
+				reason: "Global SA trying to read secrets via strict auth check"
+			}) {
+				values {
+					name
+					value
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = Null,
+		errors = {
+			{
+				locations = NotNull(),
+				message = Contains("You are authenticated"),
+				path = { "viewSecretValues" },
+			},
+		},
+	}
+end)

--- a/integration_tests/zz_spec.lua
+++ b/integration_tests/zz_spec.lua
@@ -289,6 +289,44 @@ function User:admin()
 	return false
 end
 
+---@class ServiceAccount
+ServiceAccount = {}
+--- Create a new service account with a token
+---@param name string
+---@param teamSlug? string
+---@return ServiceAccount
+function ServiceAccount.new(name, teamSlug)
+	print("new")
+	return {}
+end
+
+--- The id of the service account
+---@return string
+function ServiceAccount:id()
+	print("id")
+	return ""
+end
+
+--- The name of the service account
+---@return string
+function ServiceAccount:name()
+	print("name")
+	return ""
+end
+
+--- The bearer token for authenticating as this service account
+---@return string
+function ServiceAccount:token()
+	print("token")
+	return ""
+end
+
+--- Assign a role to this service account
+---@param roleName string
+function ServiceAccount:assignRole(roleName)
+	print("assignRole")
+end
+
 ---@class IssueChecker
 IssueChecker = {}
 --- Initialize the issue checker

--- a/internal/auth/authz/authzsql/querier.go
+++ b/internal/auth/authz/authzsql/querier.go
@@ -31,7 +31,9 @@ type Querier interface {
 	ServiceAccountHasGlobalAuthorization(ctx context.Context, arg ServiceAccountHasGlobalAuthorizationParams) (bool, error)
 	ServiceAccountHasRole(ctx context.Context, arg ServiceAccountHasRoleParams) (bool, error)
 	ServiceAccountHasTeamAuthorization(ctx context.Context, arg ServiceAccountHasTeamAuthorizationParams) (bool, error)
-	// Strict team membership check for service accounts WITHOUT admin bypass
+	// Strict team membership check for service accounts WITHOUT admin bypass.
+	// Unlike ServiceAccountHasTeamAuthorization, global service accounts (team_slug IS NULL)
+	// do NOT pass this check — the SA must belong to the specific team.
 	ServiceAccountHasTeamMembership(ctx context.Context, arg ServiceAccountHasTeamMembershipParams) (bool, error)
 	UserCanAssignRole(ctx context.Context, arg UserCanAssignRoleParams) (bool, error)
 }

--- a/internal/auth/authz/authzsql/querier.go
+++ b/internal/auth/authz/authzsql/querier.go
@@ -31,9 +31,7 @@ type Querier interface {
 	ServiceAccountHasGlobalAuthorization(ctx context.Context, arg ServiceAccountHasGlobalAuthorizationParams) (bool, error)
 	ServiceAccountHasRole(ctx context.Context, arg ServiceAccountHasRoleParams) (bool, error)
 	ServiceAccountHasTeamAuthorization(ctx context.Context, arg ServiceAccountHasTeamAuthorizationParams) (bool, error)
-	// Strict team membership check for service accounts WITHOUT admin bypass.
-	// Unlike ServiceAccountHasTeamAuthorization, global service accounts (team_slug IS NULL)
-	// do NOT pass this check — the SA must belong to the specific team.
+	// Strict team membership check for service accounts WITHOUT admin bypass
 	ServiceAccountHasTeamMembership(ctx context.Context, arg ServiceAccountHasTeamMembershipParams) (bool, error)
 	UserCanAssignRole(ctx context.Context, arg UserCanAssignRoleParams) (bool, error)
 }

--- a/internal/auth/authz/authzsql/roles.sql.go
+++ b/internal/auth/authz/authzsql/roles.sql.go
@@ -601,13 +601,13 @@ SELECT
 		SELECT
 			1
 		FROM
-			authorizations a
-			INNER JOIN role_authorizations ra ON ra.authorization_name = a.name
+			role_authorizations ra
 			INNER JOIN service_account_roles sar ON sar.role_name = ra.role_name
+			INNER JOIN service_accounts sa ON sa.id = sar.service_account_id
 		WHERE
-			sar.service_account_id = $1
-			AND a.name = $2
-			AND sar.target_team_slug = $3::slug
+			sa.id = $1
+			AND ra.authorization_name = $2
+			AND sa.team_slug = $3::slug
 	)::BOOLEAN
 `
 
@@ -617,7 +617,9 @@ type ServiceAccountHasTeamMembershipParams struct {
 	TeamSlug          slug.Slug
 }
 
-// Strict team membership check for service accounts WITHOUT admin bypass
+// Strict team membership check for service accounts WITHOUT admin bypass.
+// Unlike ServiceAccountHasTeamAuthorization, global service accounts (team_slug IS NULL)
+// do NOT pass this check — the SA must belong to the specific team.
 func (q *Queries) ServiceAccountHasTeamMembership(ctx context.Context, arg ServiceAccountHasTeamMembershipParams) (bool, error) {
 	row := q.db.QueryRow(ctx, serviceAccountHasTeamMembership, arg.ServiceAccountID, arg.AuthorizationName, arg.TeamSlug)
 	var column_1 bool

--- a/internal/auth/authz/authzsql/roles.sql.go
+++ b/internal/auth/authz/authzsql/roles.sql.go
@@ -617,9 +617,7 @@ type ServiceAccountHasTeamMembershipParams struct {
 	TeamSlug          slug.Slug
 }
 
-// Strict team membership check for service accounts WITHOUT admin bypass.
-// Unlike ServiceAccountHasTeamAuthorization, global service accounts (team_slug IS NULL)
-// do NOT pass this check — the SA must belong to the specific team.
+// Strict team membership check for service accounts WITHOUT admin bypass
 func (q *Queries) ServiceAccountHasTeamMembership(ctx context.Context, arg ServiceAccountHasTeamMembershipParams) (bool, error) {
 	row := q.db.QueryRow(ctx, serviceAccountHasTeamMembership, arg.ServiceAccountID, arg.AuthorizationName, arg.TeamSlug)
 	var column_1 bool

--- a/internal/auth/authz/queries/roles.sql
+++ b/internal/auth/authz/queries/roles.sql
@@ -55,13 +55,13 @@ SELECT
 		SELECT
 			1
 		FROM
-			authorizations a
-			INNER JOIN role_authorizations ra ON ra.authorization_name = a.name
+			role_authorizations ra
 			INNER JOIN service_account_roles sar ON sar.role_name = ra.role_name
+			INNER JOIN service_accounts sa ON sa.id = sar.service_account_id
 		WHERE
-			sar.service_account_id = @service_account_id
-			AND a.name = @authorization_name
-			AND sar.target_team_slug = @team_slug::slug
+			sa.id = @service_account_id
+			AND ra.authorization_name = @authorization_name
+			AND sa.team_slug = @team_slug::slug
 	)::BOOLEAN
 ;
 

--- a/internal/integration/manager.go
+++ b/internal/integration/manager.go
@@ -67,6 +67,7 @@ func TestRunner(ctx context.Context, skipSetup bool) (*testmanager.Manager, func
 
 	mgr.AddTypemetatable(teamMetatable())
 	mgr.AddTypemetatable(userMetatable())
+	mgr.AddTypemetatable(serviceAccountMetatable())
 	mgr.AddTypemetatable(issueCheckerMetatable())
 
 	return mgr, func() {

--- a/internal/integration/serviceaccount_helper.go
+++ b/internal/integration/serviceaccount_helper.go
@@ -1,0 +1,188 @@
+//go:build integration_test
+
+package integration
+
+import (
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/nais/api/internal/auth/authz/authzsql"
+	"github.com/nais/api/internal/serviceaccount"
+	"github.com/nais/api/internal/serviceaccount/serviceaccountsql"
+	"github.com/nais/api/internal/slug"
+	"github.com/nais/tester/lua/spec"
+	lua "github.com/yuin/gopher-lua"
+)
+
+const luaServiceAccountTypeName = "ServiceAccount"
+
+type ServiceAccount struct {
+	ID       uuid.UUID
+	Name     string
+	TeamSlug *slug.Slug
+	// The plaintext token, only available after creation
+	Token string
+}
+
+func serviceAccountMetatable() *spec.Typemetatable {
+	return &spec.Typemetatable{
+		Name: luaServiceAccountTypeName,
+		Init: &spec.Function{
+			Doc: "Create a new service account with a token",
+			Args: []spec.Argument{
+				{
+					Name: "name",
+					Type: []spec.ArgumentType{spec.ArgumentTypeString},
+					Doc:  "The name of the service account",
+				},
+				{
+					Name: "teamSlug?",
+					Type: []spec.ArgumentType{spec.ArgumentTypeString},
+					Doc:  "The team slug to scope the service account to (optional, global if omitted)",
+				},
+			},
+			Func: createServiceAccount,
+		},
+		GetSet: []spec.TypemetatableGetSet{
+			{
+				Name:       "id",
+				Doc:        "The id of the service account",
+				GetReturns: []spec.ArgumentType{spec.ArgumentTypeString},
+				Func:       serviceAccountGetID,
+			},
+			{
+				Name:       "name",
+				Doc:        "The name of the service account",
+				GetReturns: []spec.ArgumentType{spec.ArgumentTypeString},
+				Func:       serviceAccountGetName,
+			},
+			{
+				Name:       "token",
+				Doc:        "The bearer token for authenticating as this service account",
+				GetReturns: []spec.ArgumentType{spec.ArgumentTypeString},
+				Func:       serviceAccountGetToken,
+			},
+		},
+		Methods: []spec.Function{
+			{
+				Name: "assignRole",
+				Doc:  "Assign a role to this service account",
+				Args: []spec.Argument{
+					{
+						Name: "roleName",
+						Type: []spec.ArgumentType{spec.ArgumentTypeString},
+						Doc:  "The name of the role to assign",
+					},
+				},
+				Func: serviceAccountAssignRole,
+			},
+		},
+	}
+}
+
+func createServiceAccount(L *lua.LState) int {
+	pool := L.Context().Value(databaseKey).(*pgxpool.Pool)
+	saDB := serviceaccountsql.New(pool)
+
+	name := L.CheckString(1)
+
+	var teamSlug *slug.Slug
+	if ts := L.OptString(2, ""); ts != "" {
+		s := slug.Slug(ts)
+		teamSlug = &s
+	}
+
+	sa, err := saDB.Create(L.Context(), serviceaccountsql.CreateParams{
+		Name:        name,
+		Description: "Integration test service account",
+		TeamSlug:    teamSlug,
+	})
+	if err != nil {
+		L.RaiseError("failed to create service account: %s", err)
+		return 0
+	}
+
+	// Generate a token and store its hash
+	plaintext, err := serviceaccount.GenerateToken()
+	if err != nil {
+		L.RaiseError("failed to generate token: %s", err)
+		return 0
+	}
+
+	hashed, err := serviceaccount.HashToken(plaintext)
+	if err != nil {
+		L.RaiseError("failed to hash token: %s", err)
+		return 0
+	}
+
+	_, err = saDB.CreateToken(L.Context(), serviceaccountsql.CreateTokenParams{
+		Name:             "test-token",
+		Description:      "Integration test token",
+		Token:            hashed,
+		ServiceAccountID: sa.ID,
+		ExpiresAt:        pgtype.Date{}, // no expiry
+	})
+	if err != nil {
+		L.RaiseError("failed to create token: %s", err)
+		return 0
+	}
+
+	ret := &ServiceAccount{
+		ID:       sa.ID,
+		Name:     sa.Name,
+		TeamSlug: teamSlug,
+		Token:    plaintext,
+	}
+
+	ud := L.NewUserData()
+	ud.Value = ret
+	L.SetMetatable(ud, L.GetTypeMetatable(luaServiceAccountTypeName))
+	L.Push(ud)
+	return 1
+}
+
+func serviceAccountGetID(L *lua.LState) int {
+	sa := checkServiceAccount(L)
+	L.Push(lua.LString(sa.ID.String()))
+	return 1
+}
+
+func serviceAccountGetName(L *lua.LState) int {
+	sa := checkServiceAccount(L)
+	L.Push(lua.LString(sa.Name))
+	return 1
+}
+
+func serviceAccountGetToken(L *lua.LState) int {
+	sa := checkServiceAccount(L)
+	L.Push(lua.LString(sa.Token))
+	return 1
+}
+
+func serviceAccountAssignRole(L *lua.LState) int {
+	sa := checkServiceAccount(L)
+	roleName := L.CheckString(2)
+
+	pool := L.Context().Value(databaseKey).(*pgxpool.Pool)
+	authzDB := authzsql.New(pool)
+
+	err := authzDB.AssignRoleToServiceAccount(L.Context(), authzsql.AssignRoleToServiceAccountParams{
+		ServiceAccountID: sa.ID,
+		RoleName:         roleName,
+	})
+	if err != nil {
+		L.RaiseError("failed to assign role %q to service account: %s", roleName, err)
+		return 0
+	}
+
+	return 0
+}
+
+func checkServiceAccount(L *lua.LState) *ServiceAccount {
+	ud := L.CheckUserData(1)
+	if v, ok := ud.Value.(*ServiceAccount); ok {
+		return v
+	}
+	L.ArgError(1, "ServiceAccount expected")
+	return nil
+}

--- a/internal/search/bleve.go
+++ b/internal/search/bleve.go
@@ -55,6 +55,7 @@ func buildIndexMapping() (mapping.IndexMapping, error) {
 	docMapping := bleve.NewDocumentMapping()
 	docMapping.AddFieldMappingsAt("kind", bleve.NewKeywordFieldMapping())
 	docMapping.AddFieldMappingsAt("name", bleve.NewTextFieldMapping(), bleve.NewKeywordFieldMapping())
+	docMapping.AddFieldMappingsAt("team", bleve.NewKeywordFieldMapping())
 	indexMapping.AddDocumentMapping("doc", docMapping)
 
 	err := indexMapping.AddCustomAnalyzer(custom.Name,

--- a/internal/serviceaccount/queries.go
+++ b/internal/serviceaccount/queries.go
@@ -187,7 +187,7 @@ func CreateToken(ctx context.Context, input CreateServiceAccountTokenInput) (*Se
 		return nil, nil, nil, err
 	}
 
-	secret, err := generateToken()
+	secret, err := GenerateToken()
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/internal/serviceaccount/token.go
+++ b/internal/serviceaccount/token.go
@@ -18,7 +18,7 @@ func HashToken(token string) (string, error) {
 	return base58.Encode(sha256Hash.Sum(nil)), nil
 }
 
-func generateToken() (string, error) {
+func GenerateToken() (string, error) {
 	b := make([]byte, 64)
 	if _, err := rand.Read(b); err != nil {
 		return "", err


### PR DESCRIPTION
test

- Correct SQL for ServiceAccountHasTeamMembership to require exact team match
- Add integration test for strict team membership with service accounts