### PR TITLE
fix: add keyword mapping for team field in search index

### DIFF
--- a/internal/search/bleve.go
+++ b/internal/search/bleve.go
@@ -55,6 +55,7 @@ func buildIndexMapping() (mapping.IndexMapping, error) {
 	docMapping := bleve.NewDocumentMapping()
 	docMapping.AddFieldMappingsAt("kind", bleve.NewKeywordFieldMapping())
 	docMapping.AddFieldMappingsAt("name", bleve.NewTextFieldMapping(), bleve.NewKeywordFieldMapping())
+	docMapping.AddFieldMappingsAt("team", bleve.NewKeywordFieldMapping())
 	indexMapping.AddDocumentMapping("doc", docMapping)
 
 	err := indexMapping.AddCustomAnalyzer(custom.Name,


### PR DESCRIPTION
The team field had no explicit field mapping, causing Bleve to tokenize slugs like 'nais-verification' into ['nais', 'verification']. A term query for 'nais' would then match both teams. Adding a keyword mapping keeps the slug as a single untokenized value for exact matching.