### PR TITLE
Add workload state counts to team inventory

### DIFF
--- a/internal/graph/applications.resolvers.go
+++ b/internal/graph/applications.resolvers.go
@@ -172,10 +172,14 @@ func (r *teamEnvironmentResolver) Application(ctx context.Context, obj *team.Tea
 
 func (r *teamInventoryCountsResolver) Applications(ctx context.Context, obj *team.TeamInventoryCounts) (*application.TeamInventoryCountApplications, error) {
 	apps := application.ListAllForTeam(ctx, obj.TeamSlug, nil, nil)
+	running, notRunning, unknown := application.StateCounts(ctx, apps)
 
 	return &application.TeamInventoryCountApplications{
-		Total:    len(apps),
-		TeamSlug: obj.TeamSlug,
+		Total:      len(apps),
+		Running:    running,
+		NotRunning: notRunning,
+		Unknown:    unknown,
+		TeamSlug:   obj.TeamSlug,
 	}, nil
 }
 

--- a/internal/graph/gengql/applications.generated.go
+++ b/internal/graph/gengql/applications.generated.go
@@ -3982,6 +3982,75 @@ func (ec *executionContext) fieldContext_TeamInventoryCountApplications_total(_ 
 	return graphql.NewScalarFieldContext("TeamInventoryCountApplications", field, false, false, errors.New("field of type Int does not have child fields"))
 }
 
+func (ec *executionContext) _TeamInventoryCountApplications_running(ctx context.Context, field graphql.CollectedField, obj *application.TeamInventoryCountApplications) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TeamInventoryCountApplications_running(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Running, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TeamInventoryCountApplications_running(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TeamInventoryCountApplications", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TeamInventoryCountApplications_notRunning(ctx context.Context, field graphql.CollectedField, obj *application.TeamInventoryCountApplications) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TeamInventoryCountApplications_notRunning(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.NotRunning, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TeamInventoryCountApplications_notRunning(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TeamInventoryCountApplications", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TeamInventoryCountApplications_unknown(ctx context.Context, field graphql.CollectedField, obj *application.TeamInventoryCountApplications) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TeamInventoryCountApplications_unknown(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Unknown, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TeamInventoryCountApplications_unknown(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TeamInventoryCountApplications", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -6721,6 +6790,21 @@ func (ec *executionContext) _TeamInventoryCountApplications(ctx context.Context,
 			out.Values[i] = graphql.MarshalString("TeamInventoryCountApplications")
 		case "total":
 			out.Values[i] = ec._TeamInventoryCountApplications_total(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "running":
+			out.Values[i] = ec._TeamInventoryCountApplications_running(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "notRunning":
+			out.Values[i] = ec._TeamInventoryCountApplications_notRunning(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "unknown":
+			out.Values[i] = ec._TeamInventoryCountApplications_unknown(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/internal/graph/gengql/jobs.generated.go
+++ b/internal/graph/gengql/jobs.generated.go
@@ -3765,6 +3765,98 @@ func (ec *executionContext) fieldContext_TeamInventoryCountJobs_total(_ context.
 	return graphql.NewScalarFieldContext("TeamInventoryCountJobs", field, false, false, errors.New("field of type Int does not have child fields"))
 }
 
+func (ec *executionContext) _TeamInventoryCountJobs_running(ctx context.Context, field graphql.CollectedField, obj *job.TeamInventoryCountJobs) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TeamInventoryCountJobs_running(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Running, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TeamInventoryCountJobs_running(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TeamInventoryCountJobs", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TeamInventoryCountJobs_completed(ctx context.Context, field graphql.CollectedField, obj *job.TeamInventoryCountJobs) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TeamInventoryCountJobs_completed(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Completed, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TeamInventoryCountJobs_completed(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TeamInventoryCountJobs", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TeamInventoryCountJobs_failed(ctx context.Context, field graphql.CollectedField, obj *job.TeamInventoryCountJobs) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TeamInventoryCountJobs_failed(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Failed, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TeamInventoryCountJobs_failed(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TeamInventoryCountJobs", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TeamInventoryCountJobs_unknown(ctx context.Context, field graphql.CollectedField, obj *job.TeamInventoryCountJobs) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TeamInventoryCountJobs_unknown(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Unknown, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TeamInventoryCountJobs_unknown(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TeamInventoryCountJobs", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
 func (ec *executionContext) _TriggerJobPayload_job(ctx context.Context, field graphql.CollectedField, obj *job.TriggerJobPayload) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -6263,6 +6355,26 @@ func (ec *executionContext) _TeamInventoryCountJobs(ctx context.Context, sel ast
 			out.Values[i] = graphql.MarshalString("TeamInventoryCountJobs")
 		case "total":
 			out.Values[i] = ec._TeamInventoryCountJobs_total(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "running":
+			out.Values[i] = ec._TeamInventoryCountJobs_running(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "completed":
+			out.Values[i] = ec._TeamInventoryCountJobs_completed(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "failed":
+			out.Values[i] = ec._TeamInventoryCountJobs_failed(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "unknown":
+			out.Values[i] = ec._TeamInventoryCountJobs_unknown(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -2687,7 +2687,10 @@ type ComplexityRoot struct {
 	}
 
 	TeamInventoryCountApplications struct {
-		Total func(childComplexity int) int
+		NotRunning func(childComplexity int) int
+		Running    func(childComplexity int) int
+		Total      func(childComplexity int) int
+		Unknown    func(childComplexity int) int
 	}
 
 	TeamInventoryCountBigQueryDatasets struct {
@@ -2703,7 +2706,11 @@ type ComplexityRoot struct {
 	}
 
 	TeamInventoryCountJobs struct {
-		Total func(childComplexity int) int
+		Completed func(childComplexity int) int
+		Failed    func(childComplexity int) int
+		Running   func(childComplexity int) int
+		Total     func(childComplexity int) int
+		Unknown   func(childComplexity int) int
 	}
 
 	TeamInventoryCountKafkaTopics struct {
@@ -14867,12 +14874,33 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.TeamGoogleGroup.Email(childComplexity), true
 
+	case "TeamInventoryCountApplications.notRunning":
+		if e.ComplexityRoot.TeamInventoryCountApplications.NotRunning == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TeamInventoryCountApplications.NotRunning(childComplexity), true
+
+	case "TeamInventoryCountApplications.running":
+		if e.ComplexityRoot.TeamInventoryCountApplications.Running == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TeamInventoryCountApplications.Running(childComplexity), true
+
 	case "TeamInventoryCountApplications.total":
 		if e.ComplexityRoot.TeamInventoryCountApplications.Total == nil {
 			break
 		}
 
 		return e.ComplexityRoot.TeamInventoryCountApplications.Total(childComplexity), true
+
+	case "TeamInventoryCountApplications.unknown":
+		if e.ComplexityRoot.TeamInventoryCountApplications.Unknown == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TeamInventoryCountApplications.Unknown(childComplexity), true
 
 	case "TeamInventoryCountBigQueryDatasets.total":
 		if e.ComplexityRoot.TeamInventoryCountBigQueryDatasets.Total == nil {
@@ -14895,12 +14923,40 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.TeamInventoryCountConfigs.Total(childComplexity), true
 
+	case "TeamInventoryCountJobs.completed":
+		if e.ComplexityRoot.TeamInventoryCountJobs.Completed == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TeamInventoryCountJobs.Completed(childComplexity), true
+
+	case "TeamInventoryCountJobs.failed":
+		if e.ComplexityRoot.TeamInventoryCountJobs.Failed == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TeamInventoryCountJobs.Failed(childComplexity), true
+
+	case "TeamInventoryCountJobs.running":
+		if e.ComplexityRoot.TeamInventoryCountJobs.Running == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TeamInventoryCountJobs.Running(childComplexity), true
+
 	case "TeamInventoryCountJobs.total":
 		if e.ComplexityRoot.TeamInventoryCountJobs.Total == nil {
 			break
 		}
 
 		return e.ComplexityRoot.TeamInventoryCountJobs.Total(childComplexity), true
+
+	case "TeamInventoryCountJobs.unknown":
+		if e.ComplexityRoot.TeamInventoryCountJobs.Unknown == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TeamInventoryCountJobs.Unknown(childComplexity), true
 
 	case "TeamInventoryCountKafkaTopics.total":
 		if e.ComplexityRoot.TeamInventoryCountKafkaTopics.Total == nil {
@@ -18526,6 +18582,21 @@ type TeamInventoryCountApplications {
 	Total number of applications.
 	"""
 	total: Int!
+
+	"""
+	Number of applications in a running state.
+	"""
+	running: Int!
+
+	"""
+	Number of applications in a not running state.
+	"""
+	notRunning: Int!
+
+	"""
+	Number of applications in an unknown state.
+	"""
+	unknown: Int!
 }
 
 """
@@ -21863,6 +21934,18 @@ type JobRunInstanceEdge {
 type TeamInventoryCountJobs {
 	"Total number of jobs."
 	total: Int!
+
+	"Number of jobs in a running state."
+	running: Int!
+
+	"Number of jobs in a completed state."
+	completed: Int!
+
+	"Number of jobs in a failed state."
+	failed: Int!
+
+	"Number of jobs in an unknown state."
+	unknown: Int!
 }
 
 input JobOrder {
@@ -33134,6 +33217,12 @@ func (ec *executionContext) childFields_TeamInventoryCountApplications(ctx conte
 	switch field.Name {
 	case "total":
 		return ec.fieldContext_TeamInventoryCountApplications_total(ctx, field)
+	case "running":
+		return ec.fieldContext_TeamInventoryCountApplications_running(ctx, field)
+	case "notRunning":
+		return ec.fieldContext_TeamInventoryCountApplications_notRunning(ctx, field)
+	case "unknown":
+		return ec.fieldContext_TeamInventoryCountApplications_unknown(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type TeamInventoryCountApplications", field.Name)
 }
@@ -33166,6 +33255,14 @@ func (ec *executionContext) childFields_TeamInventoryCountJobs(ctx context.Conte
 	switch field.Name {
 	case "total":
 		return ec.fieldContext_TeamInventoryCountJobs_total(ctx, field)
+	case "running":
+		return ec.fieldContext_TeamInventoryCountJobs_running(ctx, field)
+	case "completed":
+		return ec.fieldContext_TeamInventoryCountJobs_completed(ctx, field)
+	case "failed":
+		return ec.fieldContext_TeamInventoryCountJobs_failed(ctx, field)
+	case "unknown":
+		return ec.fieldContext_TeamInventoryCountJobs_unknown(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type TeamInventoryCountJobs", field.Name)
 }

--- a/internal/graph/jobs.resolvers.go
+++ b/internal/graph/jobs.resolvers.go
@@ -160,10 +160,15 @@ func (r *teamEnvironmentResolver) Job(ctx context.Context, obj *team.TeamEnviron
 
 func (r *teamInventoryCountsResolver) Jobs(ctx context.Context, obj *team.TeamInventoryCounts) (*job.TeamInventoryCountJobs, error) {
 	jobs := job.ListAllForTeam(ctx, obj.TeamSlug, nil, nil)
+	running, completed, failed, unknown := job.StateCounts(ctx, jobs)
 
 	return &job.TeamInventoryCountJobs{
-		Total:    len(jobs),
-		TeamSlug: obj.TeamSlug,
+		Total:     len(jobs),
+		Running:   running,
+		Completed: completed,
+		Failed:    failed,
+		Unknown:   unknown,
+		TeamSlug:  obj.TeamSlug,
 	}, nil
 }
 

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -84,6 +84,21 @@ type TeamInventoryCountApplications {
 	Total number of applications.
 	"""
 	total: Int!
+
+	"""
+	Number of applications in a running state.
+	"""
+	running: Int!
+
+	"""
+	Number of applications in a not running state.
+	"""
+	notRunning: Int!
+
+	"""
+	Number of applications in an unknown state.
+	"""
+	unknown: Int!
 }
 
 """

--- a/internal/graph/schema/jobs.graphqls
+++ b/internal/graph/schema/jobs.graphqls
@@ -338,6 +338,18 @@ type JobRunInstanceEdge {
 type TeamInventoryCountJobs {
 	"Total number of jobs."
 	total: Int!
+
+	"Number of jobs in a running state."
+	running: Int!
+
+	"Number of jobs in a completed state."
+	completed: Int!
+
+	"Number of jobs in a failed state."
+	failed: Int!
+
+	"Number of jobs in an unknown state."
+	unknown: Int!
 }
 
 input JobOrder {

--- a/internal/workload/application/models.go
+++ b/internal/workload/application/models.go
@@ -561,8 +561,11 @@ func (e ApplicationInstanceState) MarshalGQL(w io.Writer) {
 }
 
 type TeamInventoryCountApplications struct {
-	Total    int       `json:"total"`
-	TeamSlug slug.Slug `json:"-"`
+	Total      int       `json:"total"`
+	Running    int       `json:"running"`
+	NotRunning int       `json:"notRunning"`
+	Unknown    int       `json:"unknown"`
+	TeamSlug   slug.Slug `json:"-"`
 }
 
 type Ingress struct {

--- a/internal/workload/application/queries.go
+++ b/internal/workload/application/queries.go
@@ -246,3 +246,23 @@ func GetState(ctx context.Context, obj *Application) (ApplicationState, error) {
 
 	return ApplicationStateNotRunning, nil
 }
+
+// StateCounts computes the number of applications in each state for a given list of applications.
+func StateCounts(ctx context.Context, apps []*Application) (running, notRunning, unknown int) {
+	for _, app := range apps {
+		state, err := GetState(ctx, app)
+		if err != nil {
+			unknown++
+			continue
+		}
+		switch state {
+		case ApplicationStateRunning:
+			running++
+		case ApplicationStateNotRunning:
+			notRunning++
+		default:
+			unknown++
+		}
+	}
+	return
+}

--- a/internal/workload/job/models.go
+++ b/internal/workload/job/models.go
@@ -503,8 +503,12 @@ func pluralize(s string, count int32) string {
 }
 
 type TeamInventoryCountJobs struct {
-	Total    int       `json:"total"`
-	TeamSlug slug.Slug `json:"-"`
+	Total     int       `json:"total"`
+	Running   int       `json:"running"`
+	Completed int       `json:"completed"`
+	Failed    int       `json:"failed"`
+	Unknown   int       `json:"unknown"`
+	TeamSlug  slug.Slug `json:"-"`
 }
 
 type JobRunStatus struct {

--- a/internal/workload/job/queries.go
+++ b/internal/workload/job/queries.go
@@ -298,6 +298,28 @@ func GetState(ctx context.Context, obj *Job) (JobState, error) {
 	}
 }
 
+// StateCounts computes the number of jobs in each state for a given list of jobs.
+func StateCounts(ctx context.Context, jobs []*Job) (running, completed, failed, unknown int) {
+	for _, j := range jobs {
+		state, err := GetState(ctx, j)
+		if err != nil {
+			unknown++
+			continue
+		}
+		switch state {
+		case JobStateRunning:
+			running++
+		case JobStateCompleted:
+			completed++
+		case JobStateFailed:
+			failed++
+		default:
+			unknown++
+		}
+	}
+	return
+}
+
 func allRuns(ctx context.Context, teamSlug slug.Slug, environment string, jobName string) ([]*JobRun, error) {
 	nameReq, err := labels.NewRequirement("app", selection.Equals, []string{jobName})
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adds `running`, `notRunning`, and `unknown` count fields to `TeamInventoryCountApplications`
- Adds `running`, `completed`, `failed`, and `unknown` count fields to `TeamInventoryCountJobs`
- Computes state counts on-the-fly using existing `GetState` logic (k8s watchers)

## Motivation

Console-frontend currently fetches `applications(first: 500) { nodes { state } }` to render state overview bars, which is fragile and doesn't handle pagination. These pre-aggregated counts let the frontend get state distribution without fetching all workloads.

Closes #424