### PR TITLE
Add states filter to TeamApplicationsFilter and TeamJobsFilter

### DIFF
--- a/internal/graph/gengql/applications.generated.go
+++ b/internal/graph/gengql/applications.generated.go
@@ -4166,7 +4166,7 @@ func (ec *executionContext) unmarshalInputTeamApplicationsFilter(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "environments"}
+	fieldsInOrder := [...]string{"name", "environments", "states"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -4187,6 +4187,13 @@ func (ec *executionContext) unmarshalInputTeamApplicationsFilter(ctx context.Con
 				return it, err
 			}
 			it.Environments = data
+		case "states":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("states"))
+			data, err := ec.unmarshalOApplicationState2ᚕgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplicationStateᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.States = data
 		}
 	}
 	return it, nil
@@ -7177,6 +7184,43 @@ func (ec *executionContext) unmarshalOApplicationOrder2ᚖgithubᚗcomᚋnaisᚋ
 	}
 	res, err := ec.unmarshalInputApplicationOrder(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOApplicationState2ᚕgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplicationStateᚄ(ctx context.Context, v any) ([]application.ApplicationState, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]application.ApplicationState, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNApplicationState2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplicationState(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOApplicationState2ᚕgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplicationStateᚄ(ctx context.Context, sel ast.SelectionSet, v []application.ApplicationState) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNApplicationState2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplicationState(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOTeamApplicationsFilter2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐTeamApplicationsFilter(ctx context.Context, v any) (*application.TeamApplicationsFilter, error) {

--- a/internal/graph/gengql/jobs.generated.go
+++ b/internal/graph/gengql/jobs.generated.go
@@ -3969,7 +3969,7 @@ func (ec *executionContext) unmarshalInputTeamJobsFilter(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "environments"}
+	fieldsInOrder := [...]string{"name", "environments", "states"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -3990,6 +3990,13 @@ func (ec *executionContext) unmarshalInputTeamJobsFilter(ctx context.Context, ob
 				return it, err
 			}
 			it.Environments = data
+		case "states":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("states"))
+			data, err := ec.unmarshalOJobState2ᚕgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐJobStateᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.States = data
 		}
 	}
 	return it, nil
@@ -6761,6 +6768,43 @@ func (ec *executionContext) marshalOJobSchedule2ᚖgithubᚗcomᚋnaisᚋapiᚋi
 		return graphql.Null
 	}
 	return ec._JobSchedule(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOJobState2ᚕgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐJobStateᚄ(ctx context.Context, v any) ([]job.JobState, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]job.JobState, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNJobState2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐJobState(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOJobState2ᚕgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐJobStateᚄ(ctx context.Context, sel ast.SelectionSet, v []job.JobState) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNJobState2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐJobState(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) unmarshalOTeamJobsFilter2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐTeamJobsFilter(ctx context.Context, v any) (*job.TeamJobsFilter, error) {

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -18699,6 +18699,11 @@ input TeamApplicationsFilter {
 	Filter by the name of the environment.
 	"""
 	environments: [String!]
+
+	"""
+	Filter by application state. When provided, only applications matching one of the given states are returned.
+	"""
+	states: [ApplicationState!]
 }
 
 """
@@ -21581,6 +21586,11 @@ input TeamJobsFilter {
 	Filter by the name of the environment.
 	"""
 	environments: [String!]
+
+	"""
+	Filter by job state. When provided, only jobs matching one of the given states are returned.
+	"""
+	states: [JobState!]
 }
 type Job implements Node & Workload & ActivityLogger {
 	"The globally unique ID of the job."

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -257,6 +257,11 @@ input TeamApplicationsFilter {
 	Filter by the name of the environment.
 	"""
 	environments: [String!]
+
+	"""
+	Filter by application state. When provided, only applications matching one of the given states are returned.
+	"""
+	states: [ApplicationState!]
 }
 
 """

--- a/internal/graph/schema/jobs.graphqls
+++ b/internal/graph/schema/jobs.graphqls
@@ -56,6 +56,11 @@ input TeamJobsFilter {
 	Filter by the name of the environment.
 	"""
 	environments: [String!]
+
+	"""
+	Filter by job state. When provided, only jobs matching one of the given states are returned.
+	"""
+	states: [JobState!]
 }
 type Job implements Node & Workload & ActivityLogger {
 	"The globally unique ID of the job."

--- a/internal/workload/application/models.go
+++ b/internal/workload/application/models.go
@@ -631,8 +631,9 @@ type ApplicationInstanceStatus struct {
 }
 
 type TeamApplicationsFilter struct {
-	Name         string   `json:"name"`
-	Environments []string `json:"environments"`
+	Name         string             `json:"name"`
+	Environments []string           `json:"environments"`
+	States       []ApplicationState `json:"states"`
 }
 
 type ScalingDirection string

--- a/internal/workload/application/sortfilter.go
+++ b/internal/workload/application/sortfilter.go
@@ -38,6 +38,16 @@ func init() {
 			}
 		}
 
+		if len(filter.States) > 0 {
+			s, err := GetState(ctx, v)
+			if err != nil {
+				return slices.Contains(filter.States, ApplicationStateUnknown)
+			}
+			if !slices.Contains(filter.States, s) {
+				return false
+			}
+		}
+
 		return true
 	})
 }

--- a/internal/workload/job/models.go
+++ b/internal/workload/job/models.go
@@ -513,8 +513,9 @@ type JobRunStatus struct {
 }
 
 type TeamJobsFilter struct {
-	Name         string   `json:"name"`
-	Environments []string `json:"environments"`
+	Name         string     `json:"name"`
+	Environments []string   `json:"environments"`
+	States       []JobState `json:"states"`
 }
 
 type JobRunTrigger struct {

--- a/internal/workload/job/sortfilter.go
+++ b/internal/workload/job/sortfilter.go
@@ -38,6 +38,16 @@ func init() {
 			}
 		}
 
+		if len(filter.States) > 0 {
+			s, err := GetState(ctx, v)
+			if err != nil {
+				return slices.Contains(filter.States, JobStateUnknown)
+			}
+			if !slices.Contains(filter.States, s) {
+				return false
+			}
+		}
+
 		return true
 	})
 }


### PR DESCRIPTION
## Summary

- Adds `states: [ApplicationState!]` to `TeamApplicationsFilter`
- Adds `states: [JobState!]` to `TeamJobsFilter`
- When `states` is provided, only workloads matching one of the given states are returned
- When omitted, behavior is unchanged (all states returned)
- Filter runs concurrently using existing sortfilter pool (consistent with existing filter pattern)
- On state computation error, workload is treated as `UNKNOWN`

Closes #429