### PR TITLE
ci: bump nais/fasit-deploy to v4.0.1

### DIFF
--- a/.github/workflows/console-backend-rbac-chart.yaml
+++ b/.github/workflows/console-backend-rbac-chart.yaml
@@ -57,7 +57,8 @@ jobs:
       - name: Push Chart
         run: helm push ${{ env.NAME }}*.tgz ${{ env.IMAGE_REPOSITORY }}
 
-  rollout:
+  deploy:
+    name: Deploy
     needs:
       - lint
       - build_push
@@ -66,7 +67,14 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: nais/fasit-deploy@v2 # ratchet:exclude
+      - uses: nais/fasit-deploy@v4 # ratchet:exclude
         with:
           chart: ${{ env.IMAGE_REPOSITORY }}/${{ env.NAME }}
           version: ${{ needs.build_push.outputs.version }}
+          targets: |
+            [
+              { "target": { "kind": "tenant", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "onprem", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "tenant" } },
+              { "target": { "kind": "onprem" } }
+            ]

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -81,7 +81,8 @@ jobs:
         run: |-
           helm push ${{ env.NAME }}*.tgz ${{ env.IMAGE_REPOSITORY }}
 
-  rollout:
+  deploy:
+    name: Deploy
     needs:
       - test
       - lint
@@ -91,7 +92,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: nais/fasit-deploy@v2
+      - uses: nais/fasit-deploy@58a70a338b16dc646373c91724fc7e7522d085a4 # ratchet:nais/fasit-deploy@v4.0.1
         with:
           chart: ${{ env.IMAGE_REPOSITORY }}/${{ env.NAME }}
           version: ${{ needs.build_push.outputs.version }}
+          targets: |
+            [
+              { "target": { "kind": "management", "tenant": "ci-nais" }, "wait": true },
+              { "target": { "kind": "management" } }
+            ]


### PR DESCRIPTION
Migrer fra v2 → v4.0.1. Drop `feature_name`-param (utledet fra chart). Legg til `targets` JSON: ci-nais canary wait per kind, så broad fanout per kind.