### PR TITLE
upkeep: mangler Aiven cost siden 1 november

### DIFF
--- a/internal/cost/costupdater/costupdater.go
+++ b/internal/cost/costupdater/costupdater.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	UpsertBatchSize = 100000
-	daysToFetch     = 5
+	daysToFetch     = 200
 )
 
 // bigQueryCostTableRow is a struct that represents a row in the BigQuery table


### PR DESCRIPTION
Manglet ikke all data, men har tettet igjen hullene, så enklest å bare kjøre det inn fra starten av tettingen.