### PR TITLE
feat: add updateApplication and updateJob mutations

### DIFF
--- a/integration_tests/apply.lua
+++ b/integration_tests/apply.lua
@@ -326,7 +326,7 @@ Test.gql("activity log contains ApplicationUpdatedActivityLogEntry with changedF
 			team(slug: "%s") {
 				activityLog(
 					first: 20
-					filter: { activityTypes: [GENERIC_KUBERNETES_RESOURCE_UPDATED] }
+					filter: { activityTypes: [APPLICATION_UPDATED] }
 				) {
 					nodes {
 						__typename
@@ -337,8 +337,6 @@ Test.gql("activity log contains ApplicationUpdatedActivityLogEntry with changedF
 						environmentName
 						... on ApplicationUpdatedActivityLogEntry {
 							data {
-								apiVersion
-								kind
 								changedFields {
 									field
 									oldValue
@@ -367,8 +365,6 @@ Test.gql("activity log contains ApplicationUpdatedActivityLogEntry with changedF
 							resourceName = "my-app",
 							environmentName = "dev",
 							data = {
-								apiVersion = "nais.io/v1alpha1",
-								kind = "Application",
 								changedFields = {
 									{
 										field = "spec.image",

--- a/integration_tests/update_application.lua
+++ b/integration_tests/update_application.lua
@@ -15,7 +15,7 @@ Test.gql("update application env and replicas as team member", function(t)
 					teamSlug: "slug-1"
 					environmentName: "dev"
 					name: "another-app"
-					env: [
+					environmentVariables: [
 						{ name: "FOO", value: "bar" }
 						{ name: "BAZ", value: "qux" }
 					]
@@ -68,7 +68,7 @@ Test.gql("update application no-op returns application without new activity log"
 					teamSlug: "slug-1"
 					environmentName: "dev"
 					name: "another-app"
-					env: [
+					environmentVariables: [
 						{ name: "FOO", value: "bar" }
 						{ name: "BAZ", value: "qux" }
 					]
@@ -103,7 +103,7 @@ Test.gql("update application as non-member", function(t)
 					teamSlug: "slug-1"
 					environmentName: "dev"
 					name: "another-app"
-					env: [{ name: "FOO", value: "bar" }]
+					environmentVariables: [{ name: "FOO", value: "bar" }]
 				}
 			) {
 				application {
@@ -188,7 +188,7 @@ Test.gql("update application remove env variable", function(t)
 					teamSlug: "slug-1"
 					environmentName: "dev"
 					name: "another-app"
-					env: [
+					environmentVariables: [
 						{ name: "FOO", value: null }
 					]
 				}

--- a/integration_tests/update_application.lua
+++ b/integration_tests/update_application.lua
@@ -50,8 +50,8 @@ Test.k8s("application has updated env and replicas", function(t)
 			ingresses = { "https://another-app.external.server.com" },
 			replicas = Ignore(),
 			env = {
-				{ name = "FOO", value = "bar" },
 				{ name = "BAZ", value = "qux" },
+				{ name = "FOO", value = "bar" },
 			},
 		},
 		status = Ignore(),
@@ -164,10 +164,10 @@ Test.gql("activity log contains update entry", function(t)
 							resourceName = "another-app",
 							data = {
 								changedFields = {
-									{ field = "spec.env.FOO", oldValue = Null, newValue = "bar" },
-									{ field = "spec.env.BAZ", oldValue = Null, newValue = "qux" },
-									{ field = "spec.replicas.min", oldValue = "1", newValue = "2" },
-									{ field = "spec.replicas.max", oldValue = "1", newValue = "5" },
+									{ field = "spec.env.BAZ",      oldValue = Null, newValue = "qux" },
+									{ field = "spec.env.FOO",      oldValue = Null, newValue = "bar" },
+									{ field = "spec.replicas.min", oldValue = "1",  newValue = "2" },
+									{ field = "spec.replicas.max", oldValue = "1",  newValue = "5" },
 								},
 							},
 						},

--- a/integration_tests/update_application.lua
+++ b/integration_tests/update_application.lua
@@ -1,0 +1,275 @@
+Helper.readK8sResources("k8s_resources/simple")
+
+local user = User.new()
+local nonMember = User.new()
+local team = Team.new("slug-1", "purpose", "#channel")
+team:addMember(user)
+
+Test.gql("update application env and replicas as team member", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateApplication(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "another-app"
+					env: [
+						{ name: "FOO", value: "bar" }
+						{ name: "BAZ", value: "qux" }
+					]
+					replicas: { min: 2, max: 5 }
+				}
+			) {
+				application {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateApplication = {
+				application = {
+					name = "another-app",
+				},
+			},
+		},
+	}
+end)
+
+Test.k8s("application has updated env and replicas", function(t)
+	t.check("nais.io/v1alpha1", "applications", "dev", "slug-1", "another-app", {
+		apiVersion = "nais.io/v1alpha1",
+		kind = "Application",
+		metadata = Ignore(),
+		spec = {
+			image = "navikt/app-name:latest",
+			ingresses = { "https://another-app.external.server.com" },
+			replicas = Ignore(),
+			env = {
+				{ name = "FOO", value = "bar" },
+				{ name = "BAZ", value = "qux" },
+			},
+		},
+		status = Ignore(),
+	})
+end)
+
+Test.gql("update application no-op returns application without new activity log", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateApplication(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "another-app"
+					env: [
+						{ name: "FOO", value: "bar" }
+						{ name: "BAZ", value: "qux" }
+					]
+					replicas: { min: 2, max: 5 }
+				}
+			) {
+				application {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateApplication = {
+				application = {
+					name = "another-app",
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("update application as non-member", function(t)
+	t.addHeader("x-user-email", nonMember:email())
+
+	t.query [[
+		mutation {
+			updateApplication(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "another-app"
+					env: [{ name: "FOO", value: "bar" }]
+				}
+			) {
+				application {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = Null,
+		errors = {
+			{
+				locations = NotNull(),
+				message = Contains("you need the"),
+				path = { "updateApplication" },
+			},
+		},
+	}
+end)
+
+Test.gql("activity log contains update entry", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		{
+			team(slug: "%s") {
+				activityLog(first: 10, filter: { activityTypes: [APPLICATION_UPDATED] }) {
+					nodes {
+						__typename
+						message
+						actor
+						resourceName
+						... on ApplicationUpdatedActivityLogEntry {
+							data {
+								changedFields {
+									field
+									oldValue
+									newValue
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]], team:slug()))
+
+	t.check {
+		data = {
+			team = {
+				activityLog = {
+					nodes = {
+						{
+							__typename = "ApplicationUpdatedActivityLogEntry",
+							message = "Application another-app updated",
+							actor = user:email(),
+							resourceName = "another-app",
+							data = {
+								changedFields = {
+									{ field = "spec.env.FOO", oldValue = Null, newValue = "bar" },
+									{ field = "spec.env.BAZ", oldValue = Null, newValue = "qux" },
+									{ field = "spec.replicas.min", oldValue = "1", newValue = "2" },
+									{ field = "spec.replicas.max", oldValue = "1", newValue = "5" },
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("update application remove env variable", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateApplication(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "another-app"
+					env: [
+						{ name: "FOO", value: null }
+					]
+				}
+			) {
+				application {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateApplication = {
+				application = {
+					name = "another-app",
+				},
+			},
+		},
+	}
+end)
+
+Test.k8s("application env after removal", function(t)
+	t.check("nais.io/v1alpha1", "applications", "dev", "slug-1", "another-app", {
+		apiVersion = "nais.io/v1alpha1",
+		kind = "Application",
+		metadata = Ignore(),
+		spec = {
+			image = "navikt/app-name:latest",
+			ingresses = { "https://another-app.external.server.com" },
+			replicas = Ignore(),
+			env = {
+				{ name = "BAZ", value = "qux" },
+			},
+		},
+		status = Ignore(),
+	})
+end)
+
+Test.gql("activity log contains env removal entry", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		{
+			team(slug: "%s") {
+				activityLog(first: 1, filter: { activityTypes: [APPLICATION_UPDATED] }) {
+					nodes {
+						__typename
+						resourceName
+						... on ApplicationUpdatedActivityLogEntry {
+							data {
+								changedFields {
+									field
+									oldValue
+									newValue
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]], team:slug()))
+
+	t.check {
+		data = {
+			team = {
+				activityLog = {
+					nodes = {
+						{
+							__typename = "ApplicationUpdatedActivityLogEntry",
+							resourceName = "another-app",
+							data = {
+								changedFields = {
+									{ field = "spec.env.FOO", oldValue = "bar", newValue = Null },
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)

--- a/integration_tests/update_job.lua
+++ b/integration_tests/update_job.lua
@@ -115,7 +115,7 @@ Test.k8s("job has updated env", function(t)
 			schedule = "0 0 * * *",
 			env = {
 				{ name = "MY_VAR", value = "hello" },
-				{ name = "OTHER", value = "world" },
+				{ name = "OTHER",  value = "world" },
 			},
 		},
 		status = Ignore(),
@@ -162,7 +162,7 @@ Test.gql("activity log contains job update entry", function(t)
 							data = {
 								changedFields = {
 									{ field = "spec.env.MY_VAR", oldValue = Null, newValue = "hello" },
-									{ field = "spec.env.OTHER", oldValue = Null, newValue = "world" },
+									{ field = "spec.env.OTHER",  oldValue = Null, newValue = "world" },
 								},
 							},
 						},

--- a/integration_tests/update_job.lua
+++ b/integration_tests/update_job.lua
@@ -1,0 +1,269 @@
+Helper.readK8sResources("k8s_resources/simple")
+
+local user = User.new()
+local nonMember = User.new()
+local team = Team.new("slug-1", "purpose", "#channel")
+team:addMember(user)
+
+Test.gql("update job env as team member", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateJob(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "jobname-1"
+					env: [
+						{ name: "MY_VAR", value: "hello" }
+						{ name: "OTHER", value: "world" }
+					]
+				}
+			) {
+				job {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateJob = {
+				job = {
+					name = "jobname-1",
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("update job no-op returns job without activity log", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateJob(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "jobname-1"
+					env: [
+						{ name: "MY_VAR", value: "hello" }
+						{ name: "OTHER", value: "world" }
+					]
+				}
+			) {
+				job {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateJob = {
+				job = {
+					name = "jobname-1",
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("update job as non-member", function(t)
+	t.addHeader("x-user-email", nonMember:email())
+
+	t.query [[
+		mutation {
+			updateJob(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "jobname-1"
+					env: [{ name: "MY_VAR", value: "hello" }]
+				}
+			) {
+				job {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = Null,
+		errors = {
+			{
+				locations = NotNull(),
+				message = Contains("you need the"),
+				path = { "updateJob" },
+			},
+		},
+	}
+end)
+
+Test.k8s("job has updated env", function(t)
+	t.check("nais.io/v1", "naisjobs", "dev", "slug-1", "jobname-1", {
+		apiVersion = "nais.io/v1",
+		kind = "Naisjob",
+		metadata = Ignore(),
+		spec = {
+			image = "europe-north1-docker.pkg.dev/nais/navikt/app-name:latest",
+			schedule = "0 0 * * *",
+			env = {
+				{ name = "MY_VAR", value = "hello" },
+				{ name = "OTHER", value = "world" },
+			},
+		},
+		status = Ignore(),
+	})
+end)
+
+Test.gql("activity log contains job update entry", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		{
+			team(slug: "%s") {
+				activityLog(first: 10, filter: { activityTypes: [JOB_UPDATED] }) {
+					nodes {
+						__typename
+						message
+						actor
+						resourceName
+						... on JobUpdatedActivityLogEntry {
+							data {
+								changedFields {
+									field
+									oldValue
+									newValue
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]], team:slug()))
+
+	t.check {
+		data = {
+			team = {
+				activityLog = {
+					nodes = {
+						{
+							__typename = "JobUpdatedActivityLogEntry",
+							message = "Job jobname-1 updated",
+							actor = user:email(),
+							resourceName = "jobname-1",
+							data = {
+								changedFields = {
+									{ field = "spec.env.MY_VAR", oldValue = Null, newValue = "hello" },
+									{ field = "spec.env.OTHER", oldValue = Null, newValue = "world" },
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("update job remove env variable", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateJob(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "jobname-1"
+					env: [
+						{ name: "MY_VAR", value: null }
+					]
+				}
+			) {
+				job {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateJob = {
+				job = {
+					name = "jobname-1",
+				},
+			},
+		},
+	}
+end)
+
+Test.k8s("job env after removal", function(t)
+	t.check("nais.io/v1", "naisjobs", "dev", "slug-1", "jobname-1", {
+		apiVersion = "nais.io/v1",
+		kind = "Naisjob",
+		metadata = Ignore(),
+		spec = {
+			image = "europe-north1-docker.pkg.dev/nais/navikt/app-name:latest",
+			schedule = "0 0 * * *",
+			env = {
+				{ name = "OTHER", value = "world" },
+			},
+		},
+		status = Ignore(),
+	})
+end)
+
+Test.gql("activity log contains env removal entry", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		{
+			team(slug: "%s") {
+				activityLog(first: 1, filter: { activityTypes: [JOB_UPDATED] }) {
+					nodes {
+						__typename
+						resourceName
+						... on JobUpdatedActivityLogEntry {
+							data {
+								changedFields {
+									field
+									oldValue
+									newValue
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]], team:slug()))
+
+	t.check {
+		data = {
+			team = {
+				activityLog = {
+					nodes = {
+						{
+							__typename = "JobUpdatedActivityLogEntry",
+							resourceName = "jobname-1",
+							data = {
+								changedFields = {
+									{ field = "spec.env.MY_VAR", oldValue = "hello", newValue = Null },
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)

--- a/integration_tests/update_job.lua
+++ b/integration_tests/update_job.lua
@@ -15,7 +15,7 @@ Test.gql("update job env as team member", function(t)
 					teamSlug: "slug-1"
 					environmentName: "dev"
 					name: "jobname-1"
-					env: [
+					environmentVariables: [
 						{ name: "MY_VAR", value: "hello" }
 						{ name: "OTHER", value: "world" }
 					]
@@ -49,7 +49,7 @@ Test.gql("update job no-op returns job without activity log", function(t)
 					teamSlug: "slug-1"
 					environmentName: "dev"
 					name: "jobname-1"
-					env: [
+					environmentVariables: [
 						{ name: "MY_VAR", value: "hello" }
 						{ name: "OTHER", value: "world" }
 					]
@@ -83,7 +83,7 @@ Test.gql("update job as non-member", function(t)
 					teamSlug: "slug-1"
 					environmentName: "dev"
 					name: "jobname-1"
-					env: [{ name: "MY_VAR", value: "hello" }]
+					environmentVariables: [{ name: "MY_VAR", value: "hello" }]
 				}
 			) {
 				job {
@@ -183,7 +183,7 @@ Test.gql("update job remove env variable", function(t)
 					teamSlug: "slug-1"
 					environmentName: "dev"
 					name: "jobname-1"
-					env: [
+					environmentVariables: [
 						{ name: "MY_VAR", value: null }
 					]
 				}

--- a/internal/graph/applications.resolvers.go
+++ b/internal/graph/applications.resolvers.go
@@ -156,6 +156,14 @@ func (r *mutationResolver) RestartApplication(ctx context.Context, input applica
 	}, nil
 }
 
+func (r *mutationResolver) UpdateApplication(ctx context.Context, input application.UpdateApplicationInput) (*application.UpdateApplicationPayload, error) {
+	if err := authz.CanUpdateApplications(ctx, input.TeamSlug); err != nil {
+		return nil, err
+	}
+
+	return application.Update(ctx, input)
+}
+
 func (r *restartApplicationPayloadResolver) Application(ctx context.Context, obj *application.RestartApplicationPayload) (*application.Application, error) {
 	return application.Get(ctx, obj.TeamSlug, obj.EnvironmentName, obj.ApplicationName)
 }
@@ -205,6 +213,10 @@ func (r *teamInventoryCountsResolver) Applications(ctx context.Context, obj *tea
 	}, nil
 }
 
+func (r *updateApplicationPayloadResolver) Application(ctx context.Context, obj *application.UpdateApplicationPayload) (*application.Application, error) {
+	return application.Get(ctx, obj.TeamSlug, obj.EnvironmentName, obj.ApplicationName)
+}
+
 func (r *Resolver) Application() gengql.ApplicationResolver { return &applicationResolver{r} }
 
 func (r *Resolver) ApplicationConnection() gengql.ApplicationConnectionResolver {
@@ -227,6 +239,10 @@ func (r *Resolver) RestartApplicationPayload() gengql.RestartApplicationPayloadR
 	return &restartApplicationPayloadResolver{r}
 }
 
+func (r *Resolver) UpdateApplicationPayload() gengql.UpdateApplicationPayloadResolver {
+	return &updateApplicationPayloadResolver{r}
+}
+
 type (
 	applicationResolver               struct{ *Resolver }
 	applicationConnectionResolver     struct{ *Resolver }
@@ -235,4 +251,5 @@ type (
 	ingressResolver                   struct{ *Resolver }
 	ingressMetricsResolver            struct{ *Resolver }
 	restartApplicationPayloadResolver struct{ *Resolver }
+	updateApplicationPayloadResolver  struct{ *Resolver }
 )

--- a/internal/graph/gengql/applications.generated.go
+++ b/internal/graph/gengql/applications.generated.go
@@ -4599,7 +4599,7 @@ func (ec *executionContext) unmarshalInputUpdateApplicationInput(ctx context.Con
 			it.EnvironmentName = data
 		case "env":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("env"))
-			data, err := ec.unmarshalOUpdateEnvVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInputᚄ(ctx, v)
+			data, err := ec.unmarshalOUpdateEnvironmentVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/internal/graph/gengql/applications.generated.go
+++ b/internal/graph/gengql/applications.generated.go
@@ -4569,7 +4569,7 @@ func (ec *executionContext) unmarshalInputUpdateApplicationInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "teamSlug", "environmentName", "env", "replicas"}
+	fieldsInOrder := [...]string{"name", "teamSlug", "environmentName", "environmentVariables", "replicas"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -4597,13 +4597,13 @@ func (ec *executionContext) unmarshalInputUpdateApplicationInput(ctx context.Con
 				return it, err
 			}
 			it.EnvironmentName = data
-		case "env":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("env"))
-			data, err := ec.unmarshalOUpdateEnvironmentVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInputᚄ(ctx, v)
+		case "environmentVariables":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environmentVariables"))
+			data, err := ec.unmarshalOUpdateWorkloadEnvironmentVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateWorkloadEnvironmentVariableInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Env = data
+			it.EnvironmentVariables = data
 		case "replicas":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("replicas"))
 			data, err := ec.unmarshalOUpdateApplicationReplicasInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐUpdateApplicationReplicasInput(ctx, v)

--- a/internal/graph/gengql/applications.generated.go
+++ b/internal/graph/gengql/applications.generated.go
@@ -95,6 +95,9 @@ type IngressMetricsResolver interface {
 type RestartApplicationPayloadResolver interface {
 	Application(ctx context.Context, obj *application.RestartApplicationPayload) (*application.Application, error)
 }
+type UpdateApplicationPayloadResolver interface {
+	Application(ctx context.Context, obj *application.UpdateApplicationPayload) (*application.Application, error)
+}
 
 // endregion ************************** generated!.gotpl **************************
 
@@ -3737,8 +3740,8 @@ func (ec *executionContext) _ApplicationUpdatedActivityLogEntry_data(ctx context
 			return obj.Data, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *activitylog.GenericKubernetesResourceActivityLogEntryData) graphql.Marshaler {
-			return ec.marshalNGenericKubernetesResourceActivityLogEntryData2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐGenericKubernetesResourceActivityLogEntryData(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *application.ApplicationUpdatedActivityLogEntryData) graphql.Marshaler {
+			return ec.marshalNApplicationUpdatedActivityLogEntryData2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplicationUpdatedActivityLogEntryData(ctx, selections, v)
 		},
 		true,
 		true,
@@ -3751,7 +3754,71 @@ func (ec *executionContext) fieldContext_ApplicationUpdatedActivityLogEntry_data
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_GenericKubernetesResourceActivityLogEntryData(ctx, field)
+			return ec.childFields_ApplicationUpdatedActivityLogEntryData(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ApplicationUpdatedActivityLogEntryData_changedFields(ctx context.Context, field graphql.CollectedField, obj *application.ApplicationUpdatedActivityLogEntryData) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ApplicationUpdatedActivityLogEntryData_changedFields(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ChangedFields, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*activitylog.ResourceChangedField) graphql.Marshaler {
+			return ec.marshalNResourceChangedField2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐResourceChangedFieldᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_ApplicationUpdatedActivityLogEntryData_changedFields(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ApplicationUpdatedActivityLogEntryData",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_ResourceChangedField(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ApplicationUpdatedActivityLogEntryData_gitHubActorClaims(ctx context.Context, field graphql.CollectedField, obj *application.ApplicationUpdatedActivityLogEntryData) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ApplicationUpdatedActivityLogEntryData_gitHubActorClaims(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.GitHubActorClaims, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *activitylog.GitHubActorClaims) graphql.Marshaler {
+			return ec.marshalOGitHubActorClaims2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐGitHubActorClaims(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_ApplicationUpdatedActivityLogEntryData_gitHubActorClaims(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ApplicationUpdatedActivityLogEntryData",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_GitHubActorClaims(ctx, field)
 		},
 	}
 	return fc, nil
@@ -4242,6 +4309,38 @@ func (ec *executionContext) fieldContext_TeamInventoryCountApplications_unknown(
 	return graphql.NewScalarFieldContext("TeamInventoryCountApplications", field, false, false, errors.New("field of type Int does not have child fields"))
 }
 
+func (ec *executionContext) _UpdateApplicationPayload_application(ctx context.Context, field graphql.CollectedField, obj *application.UpdateApplicationPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_UpdateApplicationPayload_application(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.UpdateApplicationPayload().Application(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *application.Application) graphql.Marshaler {
+			return ec.marshalOApplication2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplication(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_UpdateApplicationPayload_application(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateApplicationPayload",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Application(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
 // endregion **************************** field.gotpl *****************************
 
 // region    **************************** input.gotpl *****************************
@@ -4454,6 +4553,101 @@ func (ec *executionContext) unmarshalInputTeamApplicationsFilter(ctx context.Con
 				return it, err
 			}
 			it.States = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateApplicationInput(ctx context.Context, obj any) (application.UpdateApplicationInput, error) {
+	var it application.UpdateApplicationInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"name", "teamSlug", "environmentName", "env", "replicas"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "teamSlug":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("teamSlug"))
+			data, err := ec.unmarshalNSlug2githubᚗcomᚋnaisᚋapiᚋinternalᚋslugᚐSlug(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TeamSlug = data
+		case "environmentName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environmentName"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.EnvironmentName = data
+		case "env":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("env"))
+			data, err := ec.unmarshalOUpdateEnvVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Env = data
+		case "replicas":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("replicas"))
+			data, err := ec.unmarshalOUpdateApplicationReplicasInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐUpdateApplicationReplicasInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Replicas = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateApplicationReplicasInput(ctx context.Context, obj any) (application.UpdateApplicationReplicasInput, error) {
+	var it application.UpdateApplicationReplicasInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"min", "max"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "min":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("min"))
+			data, err := ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Min = data
+		case "max":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("max"))
+			data, err := ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Max = data
 		}
 	}
 	return it, nil
@@ -6619,6 +6813,47 @@ func (ec *executionContext) _ApplicationUpdatedActivityLogEntry(ctx context.Cont
 	return out
 }
 
+var applicationUpdatedActivityLogEntryDataImplementors = []string{"ApplicationUpdatedActivityLogEntryData"}
+
+func (ec *executionContext) _ApplicationUpdatedActivityLogEntryData(ctx context.Context, sel ast.SelectionSet, obj *application.ApplicationUpdatedActivityLogEntryData) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, applicationUpdatedActivityLogEntryDataImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ApplicationUpdatedActivityLogEntryData")
+		case "changedFields":
+			out.Values[i] = ec._ApplicationUpdatedActivityLogEntryData_changedFields(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "gitHubActorClaims":
+			out.Values[i] = ec._ApplicationUpdatedActivityLogEntryData_gitHubActorClaims(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var cPUScalingStrategyImplementors = []string{"CPUScalingStrategy", "ScalingStrategy"}
 
 func (ec *executionContext) _CPUScalingStrategy(ctx context.Context, sel ast.SelectionSet, obj *application.CPUScalingStrategy) graphql.Marshaler {
@@ -7194,6 +7429,73 @@ func (ec *executionContext) _TeamInventoryCountApplications(ctx context.Context,
 	return out
 }
 
+var updateApplicationPayloadImplementors = []string{"UpdateApplicationPayload"}
+
+func (ec *executionContext) _UpdateApplicationPayload(ctx context.Context, sel ast.SelectionSet, obj *application.UpdateApplicationPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateApplicationPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateApplicationPayload")
+		case "application":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UpdateApplicationPayload_application(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 // endregion **************************** object.gotpl ****************************
 
 // region    ***************************** type.gotpl *****************************
@@ -7472,6 +7774,16 @@ func (ec *executionContext) marshalNApplicationStateFacetItem2ᚕgithubᚗcomᚋ
 	return ret
 }
 
+func (ec *executionContext) marshalNApplicationUpdatedActivityLogEntryData2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplicationUpdatedActivityLogEntryData(ctx context.Context, sel ast.SelectionSet, v *application.ApplicationUpdatedActivityLogEntryData) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ApplicationUpdatedActivityLogEntryData(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalNDeleteApplicationInput2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐDeleteApplicationInput(ctx context.Context, v any) (application.DeleteApplicationInput, error) {
 	res, err := ec.unmarshalInputDeleteApplicationInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -7651,6 +7963,25 @@ func (ec *executionContext) marshalNTeamInventoryCountApplications2ᚖgithubᚗc
 	return ec._TeamInventoryCountApplications(ctx, sel, v)
 }
 
+func (ec *executionContext) unmarshalNUpdateApplicationInput2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐUpdateApplicationInput(ctx context.Context, v any) (application.UpdateApplicationInput, error) {
+	res, err := ec.unmarshalInputUpdateApplicationInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateApplicationPayload2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐUpdateApplicationPayload(ctx context.Context, sel ast.SelectionSet, v application.UpdateApplicationPayload) graphql.Marshaler {
+	return ec._UpdateApplicationPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateApplicationPayload2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐUpdateApplicationPayload(ctx context.Context, sel ast.SelectionSet, v *application.UpdateApplicationPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateApplicationPayload(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOApplication2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplication(ctx context.Context, sel ast.SelectionSet, v *application.Application) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
@@ -7715,6 +8046,14 @@ func (ec *executionContext) unmarshalOTeamApplicationsFilter2ᚖgithubᚗcomᚋn
 		return nil, nil
 	}
 	res, err := ec.unmarshalInputTeamApplicationsFilter(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOUpdateApplicationReplicasInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐUpdateApplicationReplicasInput(ctx context.Context, v any) (*application.UpdateApplicationReplicasInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputUpdateApplicationReplicasInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/internal/graph/gengql/apply.generated.go
+++ b/internal/graph/gengql/apply.generated.go
@@ -953,6 +953,32 @@ func (ec *executionContext) marshalNResourceChangedField2ᚕgithubᚗcomᚋnais�
 	return ret
 }
 
+func (ec *executionContext) marshalNResourceChangedField2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐResourceChangedFieldᚄ(ctx context.Context, sel ast.SelectionSet, v []*activitylog.ResourceChangedField) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNResourceChangedField2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐResourceChangedField(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNResourceChangedField2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐResourceChangedField(ctx context.Context, sel ast.SelectionSet, v *activitylog.ResourceChangedField) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ResourceChangedField(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalOGitHubActorClaims2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐGitHubActorClaims(ctx context.Context, sel ast.SelectionSet, v *activitylog.GitHubActorClaims) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null

--- a/internal/graph/gengql/jobs.generated.go
+++ b/internal/graph/gengql/jobs.generated.go
@@ -87,6 +87,9 @@ type JobRunResolver interface {
 type TriggerJobPayloadResolver interface {
 	Job(ctx context.Context, obj *job.TriggerJobPayload) (*job.Job, error)
 }
+type UpdateJobPayloadResolver interface {
+	Job(ctx context.Context, obj *job.UpdateJobPayload) (*job.Job, error)
+}
 
 // endregion ************************** generated!.gotpl **************************
 
@@ -3936,8 +3939,8 @@ func (ec *executionContext) _JobUpdatedActivityLogEntry_data(ctx context.Context
 			return obj.Data, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *activitylog.GenericKubernetesResourceActivityLogEntryData) graphql.Marshaler {
-			return ec.marshalNGenericKubernetesResourceActivityLogEntryData2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐGenericKubernetesResourceActivityLogEntryData(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *job.JobUpdatedActivityLogEntryData) graphql.Marshaler {
+			return ec.marshalNJobUpdatedActivityLogEntryData2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐJobUpdatedActivityLogEntryData(ctx, selections, v)
 		},
 		true,
 		true,
@@ -3950,7 +3953,71 @@ func (ec *executionContext) fieldContext_JobUpdatedActivityLogEntry_data(_ conte
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_GenericKubernetesResourceActivityLogEntryData(ctx, field)
+			return ec.childFields_JobUpdatedActivityLogEntryData(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _JobUpdatedActivityLogEntryData_changedFields(ctx context.Context, field graphql.CollectedField, obj *job.JobUpdatedActivityLogEntryData) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_JobUpdatedActivityLogEntryData_changedFields(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ChangedFields, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*activitylog.ResourceChangedField) graphql.Marshaler {
+			return ec.marshalNResourceChangedField2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐResourceChangedFieldᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_JobUpdatedActivityLogEntryData_changedFields(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "JobUpdatedActivityLogEntryData",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_ResourceChangedField(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _JobUpdatedActivityLogEntryData_gitHubActorClaims(ctx context.Context, field graphql.CollectedField, obj *job.JobUpdatedActivityLogEntryData) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_JobUpdatedActivityLogEntryData_gitHubActorClaims(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.GitHubActorClaims, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *activitylog.GitHubActorClaims) graphql.Marshaler {
+			return ec.marshalOGitHubActorClaims2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐGitHubActorClaims(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_JobUpdatedActivityLogEntryData_gitHubActorClaims(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "JobUpdatedActivityLogEntryData",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_GitHubActorClaims(ctx, field)
 		},
 	}
 	return fc, nil
@@ -4130,6 +4197,38 @@ func (ec *executionContext) fieldContext_TriggerJobPayload_jobRun(_ context.Cont
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_JobRun(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UpdateJobPayload_job(ctx context.Context, field graphql.CollectedField, obj *job.UpdateJobPayload) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_UpdateJobPayload_job(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.UpdateJobPayload().Job(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *job.Job) graphql.Marshaler {
+			return ec.marshalOJob2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐJob(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_UpdateJobPayload_job(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UpdateJobPayload",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Job(ctx, field)
 		},
 	}
 	return fc, nil
@@ -4354,6 +4453,57 @@ func (ec *executionContext) unmarshalInputTriggerJobInput(ctx context.Context, o
 				return it, err
 			}
 			it.RunName = data
+		}
+	}
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputUpdateJobInput(ctx context.Context, obj any) (job.UpdateJobInput, error) {
+	var it job.UpdateJobInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"name", "teamSlug", "environmentName", "env"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "teamSlug":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("teamSlug"))
+			data, err := ec.unmarshalNSlug2githubᚗcomᚋnaisᚋapiᚋinternalᚋslugᚐSlug(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TeamSlug = data
+		case "environmentName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environmentName"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.EnvironmentName = data
+		case "env":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("env"))
+			data, err := ec.unmarshalOUpdateEnvVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Env = data
 		}
 	}
 	return it, nil
@@ -6730,6 +6880,47 @@ func (ec *executionContext) _JobUpdatedActivityLogEntry(ctx context.Context, sel
 	return out
 }
 
+var jobUpdatedActivityLogEntryDataImplementors = []string{"JobUpdatedActivityLogEntryData"}
+
+func (ec *executionContext) _JobUpdatedActivityLogEntryData(ctx context.Context, sel ast.SelectionSet, obj *job.JobUpdatedActivityLogEntryData) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, jobUpdatedActivityLogEntryDataImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("JobUpdatedActivityLogEntryData")
+		case "changedFields":
+			out.Values[i] = ec._JobUpdatedActivityLogEntryData_changedFields(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "gitHubActorClaims":
+			out.Values[i] = ec._JobUpdatedActivityLogEntryData_gitHubActorClaims(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var teamInventoryCountJobsImplementors = []string{"TeamInventoryCountJobs"}
 
 func (ec *executionContext) _TeamInventoryCountJobs(ctx context.Context, sel ast.SelectionSet, obj *job.TeamInventoryCountJobs) graphql.Marshaler {
@@ -6835,6 +7026,73 @@ func (ec *executionContext) _TriggerJobPayload(ctx context.Context, sel ast.Sele
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "jobRun":
 			out.Values[i] = ec._TriggerJobPayload_jobRun(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var updateJobPayloadImplementors = []string{"UpdateJobPayload"}
+
+func (ec *executionContext) _UpdateJobPayload(ctx context.Context, sel ast.SelectionSet, obj *job.UpdateJobPayload) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, updateJobPayloadImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("UpdateJobPayload")
+		case "job":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UpdateJobPayload_job(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -7234,6 +7492,16 @@ func (ec *executionContext) marshalNJobStateFacetItem2ᚕgithubᚗcomᚋnaisᚋa
 	return ret
 }
 
+func (ec *executionContext) marshalNJobUpdatedActivityLogEntryData2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐJobUpdatedActivityLogEntryData(ctx context.Context, sel ast.SelectionSet, v *job.JobUpdatedActivityLogEntryData) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._JobUpdatedActivityLogEntryData(ctx, sel, v)
+}
+
 func (ec *executionContext) marshalNTeamInventoryCountJobs2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐTeamInventoryCountJobs(ctx context.Context, sel ast.SelectionSet, v job.TeamInventoryCountJobs) graphql.Marshaler {
 	return ec._TeamInventoryCountJobs(ctx, sel, &v)
 }
@@ -7265,6 +7533,25 @@ func (ec *executionContext) marshalNTriggerJobPayload2ᚖgithubᚗcomᚋnaisᚋa
 		return graphql.Null
 	}
 	return ec._TriggerJobPayload(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNUpdateJobInput2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐUpdateJobInput(ctx context.Context, v any) (job.UpdateJobInput, error) {
+	res, err := ec.unmarshalInputUpdateJobInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUpdateJobPayload2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐUpdateJobPayload(ctx context.Context, sel ast.SelectionSet, v job.UpdateJobPayload) graphql.Marshaler {
+	return ec._UpdateJobPayload(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNUpdateJobPayload2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐUpdateJobPayload(ctx context.Context, sel ast.SelectionSet, v *job.UpdateJobPayload) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._UpdateJobPayload(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOJob2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐJob(ctx context.Context, sel ast.SelectionSet, v *job.Job) graphql.Marshaler {

--- a/internal/graph/gengql/jobs.generated.go
+++ b/internal/graph/gengql/jobs.generated.go
@@ -4469,7 +4469,7 @@ func (ec *executionContext) unmarshalInputUpdateJobInput(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "teamSlug", "environmentName", "env"}
+	fieldsInOrder := [...]string{"name", "teamSlug", "environmentName", "environmentVariables"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -4497,13 +4497,13 @@ func (ec *executionContext) unmarshalInputUpdateJobInput(ctx context.Context, ob
 				return it, err
 			}
 			it.EnvironmentName = data
-		case "env":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("env"))
-			data, err := ec.unmarshalOUpdateEnvironmentVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInputᚄ(ctx, v)
+		case "environmentVariables":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environmentVariables"))
+			data, err := ec.unmarshalOUpdateWorkloadEnvironmentVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateWorkloadEnvironmentVariableInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.Env = data
+			it.EnvironmentVariables = data
 		}
 	}
 	return it, nil

--- a/internal/graph/gengql/jobs.generated.go
+++ b/internal/graph/gengql/jobs.generated.go
@@ -4499,7 +4499,7 @@ func (ec *executionContext) unmarshalInputUpdateJobInput(ctx context.Context, ob
 			it.EnvironmentName = data
 		case "env":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("env"))
-			data, err := ec.unmarshalOUpdateEnvVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInputᚄ(ctx, v)
+			data, err := ec.unmarshalOUpdateEnvironmentVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -129,6 +129,8 @@ type ResolverRoot interface {
 	UnleashInstance() UnleashInstanceResolver
 	UnleashInstanceMetrics() UnleashInstanceMetricsResolver
 	UnleashReleaseChannelIssue() UnleashReleaseChannelIssueResolver
+	UpdateApplicationPayload() UpdateApplicationPayloadResolver
+	UpdateJobPayload() UpdateJobPayloadResolver
 	UpdateTeamEnvironmentPayload() UpdateTeamEnvironmentPayloadResolver
 	User() UserResolver
 	Valkey() ValkeyResolver
@@ -401,6 +403,11 @@ type ComplexityRoot struct {
 		ResourceName    func(childComplexity int) int
 		ResourceType    func(childComplexity int) int
 		TeamSlug        func(childComplexity int) int
+	}
+
+	ApplicationUpdatedActivityLogEntryData struct {
+		ChangedFields     func(childComplexity int) int
+		GitHubActorClaims func(childComplexity int) int
 	}
 
 	AssignRoleToServiceAccountPayload struct {
@@ -1280,6 +1287,11 @@ type ComplexityRoot struct {
 		TeamSlug        func(childComplexity int) int
 	}
 
+	JobUpdatedActivityLogEntryData struct {
+		ChangedFields     func(childComplexity int) int
+		GitHubActorClaims func(childComplexity int) int
+	}
+
 	KafkaCredentials struct {
 		AccessCert     func(childComplexity int) int
 		AccessKey      func(childComplexity int) int
@@ -1467,8 +1479,10 @@ type ComplexityRoot struct {
 		StartOpenSearchMaintenance       func(childComplexity int, input servicemaintenance.StartOpenSearchMaintenanceInput) int
 		StartValkeyMaintenance           func(childComplexity int, input servicemaintenance.StartValkeyMaintenanceInput) int
 		TriggerJob                       func(childComplexity int, input job.TriggerJobInput) int
+		UpdateApplication                func(childComplexity int, input application.UpdateApplicationInput) int
 		UpdateConfigValue                func(childComplexity int, input config.UpdateConfigValueInput) int
 		UpdateImageVulnerability         func(childComplexity int, input vulnerability.UpdateImageVulnerabilityInput) int
+		UpdateJob                        func(childComplexity int, input job.UpdateJobInput) int
 		UpdateOpenSearch                 func(childComplexity int, input opensearch.UpdateOpenSearchInput) int
 		UpdateSecretValue                func(childComplexity int, input secret.UpdateSecretValueInput) int
 		UpdateServiceAccount             func(childComplexity int, input serviceaccount.UpdateServiceAccountInput) int
@@ -3051,12 +3065,20 @@ type ComplexityRoot struct {
 		Unleash             func(childComplexity int) int
 	}
 
+	UpdateApplicationPayload struct {
+		Application func(childComplexity int) int
+	}
+
 	UpdateConfigValuePayload struct {
 		Config func(childComplexity int) int
 	}
 
 	UpdateImageVulnerabilityPayload struct {
 		Vulnerability func(childComplexity int) int
+	}
+
+	UpdateJobPayload struct {
+		Job func(childComplexity int) int
 	}
 
 	UpdateOpenSearchPayload struct {
@@ -4589,6 +4611,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.ApplicationUpdatedActivityLogEntry.TeamSlug(childComplexity), true
+
+	case "ApplicationUpdatedActivityLogEntryData.changedFields":
+		if e.ComplexityRoot.ApplicationUpdatedActivityLogEntryData.ChangedFields == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ApplicationUpdatedActivityLogEntryData.ChangedFields(childComplexity), true
+
+	case "ApplicationUpdatedActivityLogEntryData.gitHubActorClaims":
+		if e.ComplexityRoot.ApplicationUpdatedActivityLogEntryData.GitHubActorClaims == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ApplicationUpdatedActivityLogEntryData.GitHubActorClaims(childComplexity), true
 
 	case "AssignRoleToServiceAccountPayload.serviceAccount":
 		if e.ComplexityRoot.AssignRoleToServiceAccountPayload.ServiceAccount == nil {
@@ -8081,6 +8117,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.JobUpdatedActivityLogEntry.TeamSlug(childComplexity), true
 
+	case "JobUpdatedActivityLogEntryData.changedFields":
+		if e.ComplexityRoot.JobUpdatedActivityLogEntryData.ChangedFields == nil {
+			break
+		}
+
+		return e.ComplexityRoot.JobUpdatedActivityLogEntryData.ChangedFields(childComplexity), true
+
+	case "JobUpdatedActivityLogEntryData.gitHubActorClaims":
+		if e.ComplexityRoot.JobUpdatedActivityLogEntryData.GitHubActorClaims == nil {
+			break
+		}
+
+		return e.ComplexityRoot.JobUpdatedActivityLogEntryData.GitHubActorClaims(childComplexity), true
+
 	case "KafkaCredentials.accessCert":
 		if e.ComplexityRoot.KafkaCredentials.AccessCert == nil {
 			break
@@ -9166,6 +9216,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Mutation.TriggerJob(childComplexity, args["input"].(job.TriggerJobInput)), true
 
+	case "Mutation.updateApplication":
+		if e.ComplexityRoot.Mutation.UpdateApplication == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateApplication_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.UpdateApplication(childComplexity, args["input"].(application.UpdateApplicationInput)), true
+
 	case "Mutation.updateConfigValue":
 		if e.ComplexityRoot.Mutation.UpdateConfigValue == nil {
 			break
@@ -9189,6 +9251,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Mutation.UpdateImageVulnerability(childComplexity, args["input"].(vulnerability.UpdateImageVulnerabilityInput)), true
+
+	case "Mutation.updateJob":
+		if e.ComplexityRoot.Mutation.UpdateJob == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_updateJob_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Mutation.UpdateJob(childComplexity, args["input"].(job.UpdateJobInput)), true
 
 	case "Mutation.updateOpenSearch":
 		if e.ComplexityRoot.Mutation.UpdateOpenSearch == nil {
@@ -16379,6 +16453,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.UnleashReleaseChannelIssue.Unleash(childComplexity), true
 
+	case "UpdateApplicationPayload.application":
+		if e.ComplexityRoot.UpdateApplicationPayload.Application == nil {
+			break
+		}
+
+		return e.ComplexityRoot.UpdateApplicationPayload.Application(childComplexity), true
+
 	case "UpdateConfigValuePayload.config":
 		if e.ComplexityRoot.UpdateConfigValuePayload.Config == nil {
 			break
@@ -16392,6 +16473,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.UpdateImageVulnerabilityPayload.Vulnerability(childComplexity), true
+
+	case "UpdateJobPayload.job":
+		if e.ComplexityRoot.UpdateJobPayload.Job == nil {
+			break
+		}
+
+		return e.ComplexityRoot.UpdateJobPayload.Job(childComplexity), true
 
 	case "UpdateOpenSearchPayload.openSearch":
 		if e.ComplexityRoot.UpdateOpenSearchPayload.OpenSearch == nil {
@@ -18029,8 +18117,12 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputTeamVulnerabilitySummaryFilter,
 		ec.unmarshalInputTeamWorkloadsFilter,
 		ec.unmarshalInputTriggerJobInput,
+		ec.unmarshalInputUpdateApplicationInput,
+		ec.unmarshalInputUpdateApplicationReplicasInput,
 		ec.unmarshalInputUpdateConfigValueInput,
+		ec.unmarshalInputUpdateEnvVariableInput,
 		ec.unmarshalInputUpdateImageVulnerabilityInput,
+		ec.unmarshalInputUpdateJobInput,
 		ec.unmarshalInputUpdateOpenSearchInput,
 		ec.unmarshalInputUpdateSecretValueInput,
 		ec.unmarshalInputUpdateServiceAccountInput,
@@ -18883,6 +18975,17 @@ extend type Mutation {
 		"""
 		input: RestartApplicationInput!
 	): RestartApplicationPayload!
+
+	"""
+	Update specific fields on an application. Only provided fields are applied.
+	Changes are temporary and will be overwritten on next deploy.
+	"""
+	updateApplication(
+		"""
+		Input for updating an application.
+		"""
+		input: UpdateApplicationInput!
+	): UpdateApplicationPayload!
 }
 
 extend type TeamInventoryCounts {
@@ -19368,6 +19471,58 @@ type RestartApplicationPayload {
 	application: Application
 }
 
+input UpdateApplicationInput {
+	"""
+	Name of the application.
+	"""
+	name: String!
+
+	"""
+	Slug of the team that owns the application.
+	"""
+	teamSlug: Slug!
+
+	"""
+	Name of the environment where the application runs.
+	"""
+	environmentName: String!
+
+	"""
+	Update environment variables. Variables are merged with existing ones.
+	"""
+	env: [UpdateEnvVariableInput!]
+
+	"""
+	Update the replica configuration.
+	"""
+	replicas: UpdateApplicationReplicasInput
+}
+
+"""
+Input for updating the replica configuration of an application.
+"""
+input UpdateApplicationReplicasInput {
+	"""
+	Minimum number of replicas.
+	"""
+	min: Int!
+
+	"""
+	Maximum number of replicas.
+	"""
+	max: Int!
+}
+
+"""
+Payload for updating an application.
+"""
+type UpdateApplicationPayload {
+	"""
+	The updated application.
+	"""
+	application: Application
+}
+
 type Ingress {
 	"""
 	URL for the ingress.
@@ -19656,6 +19811,13 @@ type ApplicationCreatedActivityLogEntry implements ActivityLogEntry & Node {
 	data: GenericKubernetesResourceActivityLogEntryData!
 }
 
+type ApplicationUpdatedActivityLogEntryData {
+	"The fields that changed during the update."
+	changedFields: [ResourceChangedField!]!
+	"GitHub Actions OIDC token claims at the time of the apply. Only present when the request was authenticated via a GitHub token."
+	gitHubActorClaims: GitHubActorClaims
+}
+
 type ApplicationUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	"ID of the entry."
 	id: ID!
@@ -19682,7 +19844,7 @@ type ApplicationUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	environmentName: String
 
 	"Data associated with the update."
-	data: GenericKubernetesResourceActivityLogEntryData!
+	data: ApplicationUpdatedActivityLogEntryData!
 }
 
 extend enum ActivityLogActivityType {
@@ -19700,6 +19862,11 @@ extend enum ActivityLogActivityType {
 	An application was scaled.
 	"""
 	APPLICATION_SCALED
+
+	"""
+	An application was updated.
+	"""
+	APPLICATION_UPDATED
 }
 `, BuiltIn: false},
 	{Name: "../schema/apply.graphqls", Input: `extend enum ActivityLogActivityType {
@@ -22000,6 +22167,17 @@ extend type Mutation {
 
 	"Trigger a job"
 	triggerJob(input: TriggerJobInput!): TriggerJobPayload!
+
+	"""
+	Update specific fields on a job. Only provided fields are applied.
+	Changes are temporary and will be overwritten on next deploy.
+	"""
+	updateJob(
+		"""
+		Input for updating a job.
+		"""
+		input: UpdateJobInput!
+	): UpdateJobPayload!
 }
 
 extend type TeamEnvironment {
@@ -22611,7 +22789,14 @@ type JobUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	environmentName: String
 
 	"Data associated with the update."
-	data: GenericKubernetesResourceActivityLogEntryData!
+	data: JobUpdatedActivityLogEntryData!
+}
+
+type JobUpdatedActivityLogEntryData {
+	"The fields that changed during the update."
+	changedFields: [ResourceChangedField!]!
+	"GitHub Actions OIDC token claims at the time of the apply. Only present when the request was authenticated via a GitHub token."
+	gitHubActorClaims: GitHubActorClaims
 }
 
 extend enum ActivityLogActivityType {
@@ -22623,6 +22808,41 @@ extend enum ActivityLogActivityType {
 
 	"Activity log entries related to job triggering."
 	JOB_TRIGGERED
+
+	"Activity log entries related to job updates."
+	JOB_UPDATED
+}
+
+input UpdateJobInput {
+	"""
+	Name of the job.
+	"""
+	name: String!
+
+	"""
+	Slug of the team that owns the job.
+	"""
+	teamSlug: Slug!
+
+	"""
+	Name of the environment where the job runs.
+	"""
+	environmentName: String!
+
+	"""
+	Update environment variables. Variables are merged with existing ones.
+	"""
+	env: [UpdateEnvVariableInput!]
+}
+
+"""
+Payload for updating a job.
+"""
+type UpdateJobPayload {
+	"""
+	The updated job.
+	"""
+	job: Job
 }
 `, BuiltIn: false},
 	{Name: "../schema/kafka.graphqls", Input: `extend type Mutation {
@@ -30243,6 +30463,21 @@ input TeamWorkloadsFilter {
 	"""
 	environments: [String!]
 }
+
+"""
+Input for setting an environment variable on a workload. To remove a variable, set value to null.
+"""
+input UpdateEnvVariableInput {
+	"""
+	Name of the environment variable.
+	"""
+	name: String!
+
+	"""
+	Value of the environment variable. Set to null to remove the variable.
+	"""
+	value: String
+}
 `, BuiltIn: false},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)
@@ -30623,6 +30858,16 @@ func (ec *executionContext) childFields_ApplicationStateFacetItem(ctx context.Co
 		return ec.fieldContext_ApplicationStateFacetItem_count(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type ApplicationStateFacetItem", field.Name)
+}
+
+func (ec *executionContext) childFields_ApplicationUpdatedActivityLogEntryData(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "changedFields":
+		return ec.fieldContext_ApplicationUpdatedActivityLogEntryData_changedFields(ctx, field)
+	case "gitHubActorClaims":
+		return ec.fieldContext_ApplicationUpdatedActivityLogEntryData_gitHubActorClaims(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type ApplicationUpdatedActivityLogEntryData", field.Name)
 }
 
 func (ec *executionContext) childFields_AssignRoleToServiceAccountPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -31967,6 +32212,16 @@ func (ec *executionContext) childFields_JobStateFacetItem(ctx context.Context, f
 		return ec.fieldContext_JobStateFacetItem_count(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type JobStateFacetItem", field.Name)
+}
+
+func (ec *executionContext) childFields_JobUpdatedActivityLogEntryData(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "changedFields":
+		return ec.fieldContext_JobUpdatedActivityLogEntryData_changedFields(ctx, field)
+	case "gitHubActorClaims":
+		return ec.fieldContext_JobUpdatedActivityLogEntryData_gitHubActorClaims(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type JobUpdatedActivityLogEntryData", field.Name)
 }
 
 func (ec *executionContext) childFields_KafkaCredentials(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -34179,6 +34434,14 @@ func (ec *executionContext) childFields_UnleashReleaseChannel(ctx context.Contex
 	return nil, fmt.Errorf("no field named %q was found under type UnleashReleaseChannel", field.Name)
 }
 
+func (ec *executionContext) childFields_UpdateApplicationPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "application":
+		return ec.fieldContext_UpdateApplicationPayload_application(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type UpdateApplicationPayload", field.Name)
+}
+
 func (ec *executionContext) childFields_UpdateConfigValuePayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
 	case "config":
@@ -34193,6 +34456,14 @@ func (ec *executionContext) childFields_UpdateImageVulnerabilityPayload(ctx cont
 		return ec.fieldContext_UpdateImageVulnerabilityPayload_vulnerability(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type UpdateImageVulnerabilityPayload", field.Name)
+}
+
+func (ec *executionContext) childFields_UpdateJobPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "job":
+		return ec.fieldContext_UpdateJobPayload_job(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type UpdateJobPayload", field.Name)
 }
 
 func (ec *executionContext) childFields_UpdateOpenSearchPayload(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -18120,7 +18120,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateApplicationInput,
 		ec.unmarshalInputUpdateApplicationReplicasInput,
 		ec.unmarshalInputUpdateConfigValueInput,
-		ec.unmarshalInputUpdateEnvironmentVariableInput,
 		ec.unmarshalInputUpdateImageVulnerabilityInput,
 		ec.unmarshalInputUpdateJobInput,
 		ec.unmarshalInputUpdateOpenSearchInput,
@@ -18131,6 +18130,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateTeamInput,
 		ec.unmarshalInputUpdateUnleashInstanceInput,
 		ec.unmarshalInputUpdateValkeyInput,
+		ec.unmarshalInputUpdateWorkloadEnvironmentVariableInput,
 		ec.unmarshalInputUserOrder,
 		ec.unmarshalInputUserTeamOrder,
 		ec.unmarshalInputValkeyAccessOrder,
@@ -19493,7 +19493,7 @@ input UpdateApplicationInput {
 	"""
 	Update environment variables. Variables are merged with existing ones.
 	"""
-	env: [UpdateEnvironmentVariableInput!]
+	environmentVariables: [UpdateWorkloadEnvironmentVariableInput!]
 
 	"""
 	Update the replica configuration.
@@ -22844,7 +22844,7 @@ input UpdateJobInput {
 	"""
 	Update environment variables. Variables are merged with existing ones.
 	"""
-	env: [UpdateEnvironmentVariableInput!]
+	environmentVariables: [UpdateWorkloadEnvironmentVariableInput!]
 }
 
 """
@@ -30479,7 +30479,7 @@ input TeamWorkloadsFilter {
 """
 Input for setting an environment variable on a workload. To remove a variable, set value to null.
 """
-input UpdateEnvironmentVariableInput {
+input UpdateWorkloadEnvironmentVariableInput {
 	"""
 	Name of the environment variable.
 	"""

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -19471,6 +19471,9 @@ type RestartApplicationPayload {
 	application: Application
 }
 
+"""
+Input for updating an application.
+"""
 input UpdateApplicationInput {
 	"""
 	Name of the application.
@@ -22766,6 +22769,9 @@ type JobCreatedActivityLogEntry implements ActivityLogEntry & Node {
 	data: GenericKubernetesResourceActivityLogEntryData!
 }
 
+"""
+Activity log entry for when a job is updated.
+"""
 type JobUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	"ID of the entry."
 	id: ID!
@@ -22795,6 +22801,9 @@ type JobUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	data: JobUpdatedActivityLogEntryData!
 }
 
+"""
+Data associated with a job update activity log entry.
+"""
 type JobUpdatedActivityLogEntryData {
 	"The fields that changed during the update."
 	changedFields: [ResourceChangedField!]!

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -18120,7 +18120,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputUpdateApplicationInput,
 		ec.unmarshalInputUpdateApplicationReplicasInput,
 		ec.unmarshalInputUpdateConfigValueInput,
-		ec.unmarshalInputUpdateEnvVariableInput,
+		ec.unmarshalInputUpdateEnvironmentVariableInput,
 		ec.unmarshalInputUpdateImageVulnerabilityInput,
 		ec.unmarshalInputUpdateJobInput,
 		ec.unmarshalInputUpdateOpenSearchInput,
@@ -19490,7 +19490,7 @@ input UpdateApplicationInput {
 	"""
 	Update environment variables. Variables are merged with existing ones.
 	"""
-	env: [UpdateEnvVariableInput!]
+	env: [UpdateEnvironmentVariableInput!]
 
 	"""
 	Update the replica configuration.
@@ -19811,6 +19811,9 @@ type ApplicationCreatedActivityLogEntry implements ActivityLogEntry & Node {
 	data: GenericKubernetesResourceActivityLogEntryData!
 }
 
+"""
+Data associated with an application update activity log entry.
+"""
 type ApplicationUpdatedActivityLogEntryData {
 	"The fields that changed during the update."
 	changedFields: [ResourceChangedField!]!
@@ -19818,6 +19821,9 @@ type ApplicationUpdatedActivityLogEntryData {
 	gitHubActorClaims: GitHubActorClaims
 }
 
+"""
+Activity log entry for when an application is updated.
+"""
 type ApplicationUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	"ID of the entry."
 	id: ID!
@@ -19870,9 +19876,6 @@ extend enum ActivityLogActivityType {
 }
 `, BuiltIn: false},
 	{Name: "../schema/apply.graphqls", Input: `extend enum ActivityLogActivityType {
-	"A generic kubernetes resource was updated via apply."
-	GENERIC_KUBERNETES_RESOURCE_UPDATED
-
 	"A generic kubernetes resource was created via apply."
 	GENERIC_KUBERNETES_RESOURCE_CREATED
 }
@@ -22832,7 +22835,7 @@ input UpdateJobInput {
 	"""
 	Update environment variables. Variables are merged with existing ones.
 	"""
-	env: [UpdateEnvVariableInput!]
+	env: [UpdateEnvironmentVariableInput!]
 }
 
 """
@@ -30467,7 +30470,7 @@ input TeamWorkloadsFilter {
 """
 Input for setting an environment variable on a workload. To remove a variable, set value to null.
 """
-input UpdateEnvVariableInput {
+input UpdateEnvironmentVariableInput {
 	"""
 	Name of the environment variable.
 	"""

--- a/internal/graph/gengql/schema.generated.go
+++ b/internal/graph/gengql/schema.generated.go
@@ -66,6 +66,7 @@ import (
 type MutationResolver interface {
 	DeleteApplication(ctx context.Context, input application.DeleteApplicationInput) (*application.DeleteApplicationPayload, error)
 	RestartApplication(ctx context.Context, input application.RestartApplicationInput) (*application.RestartApplicationPayload, error)
+	UpdateApplication(ctx context.Context, input application.UpdateApplicationInput) (*application.UpdateApplicationPayload, error)
 	CreateConfig(ctx context.Context, input config.CreateConfigInput) (*config.CreateConfigPayload, error)
 	AddConfigValue(ctx context.Context, input config.AddConfigValueInput) (*config.AddConfigValuePayload, error)
 	UpdateConfigValue(ctx context.Context, input config.UpdateConfigValueInput) (*config.UpdateConfigValuePayload, error)
@@ -75,6 +76,7 @@ type MutationResolver interface {
 	DeleteJob(ctx context.Context, input job.DeleteJobInput) (*job.DeleteJobPayload, error)
 	DeleteJobRun(ctx context.Context, input job.DeleteJobRunInput) (*job.DeleteJobRunPayload, error)
 	TriggerJob(ctx context.Context, input job.TriggerJobInput) (*job.TriggerJobPayload, error)
+	UpdateJob(ctx context.Context, input job.UpdateJobInput) (*job.UpdateJobPayload, error)
 	CreateKafkaCredentials(ctx context.Context, input kafkatopic.CreateKafkaCredentialsInput) (*kafkatopic.CreateKafkaCredentialsPayload, error)
 	CreateOpenSearch(ctx context.Context, input opensearch.CreateOpenSearchInput) (*opensearch.CreateOpenSearchPayload, error)
 	UpdateOpenSearch(ctx context.Context, input opensearch.UpdateOpenSearchInput) (*opensearch.UpdateOpenSearchPayload, error)
@@ -832,6 +834,20 @@ func (ec *executionContext) field_Mutation_triggerJob_args(ctx context.Context, 
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_updateApplication_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input",
+		func(ctx context.Context, v any) (application.UpdateApplicationInput, error) {
+			return ec.unmarshalNUpdateApplicationInput2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐUpdateApplicationInput(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_updateConfigValue_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -852,6 +868,20 @@ func (ec *executionContext) field_Mutation_updateImageVulnerability_args(ctx con
 	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input",
 		func(ctx context.Context, v any) (vulnerability.UpdateImageVulnerabilityInput, error) {
 			return ec.unmarshalNUpdateImageVulnerabilityInput2githubᚗcomᚋnaisᚋapiᚋinternalᚋvulnerabilityᚐUpdateImageVulnerabilityInput(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["input"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Mutation_updateJob_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "input",
+		func(ctx context.Context, v any) (job.UpdateJobInput, error) {
+			return ec.unmarshalNUpdateJobInput2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐUpdateJobInput(ctx, v)
 		})
 	if err != nil {
 		return nil, err
@@ -1692,6 +1722,50 @@ func (ec *executionContext) fieldContext_Mutation_restartApplication(ctx context
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_updateApplication(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_updateApplication(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().UpdateApplication(ctx, fc.Args["input"].(application.UpdateApplicationInput))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *application.UpdateApplicationPayload) graphql.Marshaler {
+			return ec.marshalNUpdateApplicationPayload2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐUpdateApplicationPayload(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_updateApplication(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_UpdateApplicationPayload(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateApplication_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Mutation_createConfig(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -2082,6 +2156,50 @@ func (ec *executionContext) fieldContext_Mutation_triggerJob(ctx context.Context
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Mutation_triggerJob_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Mutation_updateJob(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Mutation_updateJob(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Mutation().UpdateJob(ctx, fc.Args["input"].(job.UpdateJobInput))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *job.UpdateJobPayload) graphql.Marshaler {
+			return ec.marshalNUpdateJobPayload2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋjobᚐUpdateJobPayload(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Mutation_updateJob(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_UpdateJobPayload(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_updateJob_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -6529,6 +6647,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "updateApplication":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateApplication(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		case "createConfig":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_createConfig(ctx, field)
@@ -6588,6 +6713,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 		case "triggerJob":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Mutation_triggerJob(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "updateJob":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_updateJob(ctx, field)
 			})
 			if out.Values[i] == graphql.Null {
 				out.Invalids++

--- a/internal/graph/gengql/workloads.generated.go
+++ b/internal/graph/gengql/workloads.generated.go
@@ -798,8 +798,8 @@ func (ec *executionContext) unmarshalInputTeamWorkloadsFilter(ctx context.Contex
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputUpdateEnvVariableInput(ctx context.Context, obj any) (workload.UpdateEnvVariableInput, error) {
-	var it workload.UpdateEnvVariableInput
+func (ec *executionContext) unmarshalInputUpdateEnvironmentVariableInput(ctx context.Context, obj any) (workload.UpdateEnvironmentVariableInput, error) {
+	var it workload.UpdateEnvironmentVariableInput
 	if obj == nil {
 		return it, nil
 	}
@@ -1535,8 +1535,8 @@ func (ec *executionContext) marshalNEnvironmentWorkloadOrderField2githubᚗcom�
 	return v
 }
 
-func (ec *executionContext) unmarshalNUpdateEnvVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInput(ctx context.Context, v any) (*workload.UpdateEnvVariableInput, error) {
-	res, err := ec.unmarshalInputUpdateEnvVariableInput(ctx, v)
+func (ec *executionContext) unmarshalNUpdateEnvironmentVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInput(ctx context.Context, v any) (*workload.UpdateEnvironmentVariableInput, error) {
+	res, err := ec.unmarshalInputUpdateEnvironmentVariableInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -1646,17 +1646,17 @@ func (ec *executionContext) unmarshalOTeamWorkloadsFilter2ᚖgithubᚗcomᚋnais
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalOUpdateEnvVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInputᚄ(ctx context.Context, v any) ([]*workload.UpdateEnvVariableInput, error) {
+func (ec *executionContext) unmarshalOUpdateEnvironmentVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInputᚄ(ctx context.Context, v any) ([]*workload.UpdateEnvironmentVariableInput, error) {
 	if v == nil {
 		return nil, nil
 	}
 	var vSlice []any
 	vSlice = graphql.CoerceList(v)
 	var err error
-	res := make([]*workload.UpdateEnvVariableInput, len(vSlice))
+	res := make([]*workload.UpdateEnvironmentVariableInput, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNUpdateEnvVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInput(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNUpdateEnvironmentVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInput(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}

--- a/internal/graph/gengql/workloads.generated.go
+++ b/internal/graph/gengql/workloads.generated.go
@@ -798,6 +798,43 @@ func (ec *executionContext) unmarshalInputTeamWorkloadsFilter(ctx context.Contex
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputUpdateEnvVariableInput(ctx context.Context, obj any) (workload.UpdateEnvVariableInput, error) {
+	var it workload.UpdateEnvVariableInput
+	if obj == nil {
+		return it, nil
+	}
+
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"name", "value"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "name":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("name"))
+			data, err := ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Name = data
+		case "value":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("value"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Value = data
+		}
+	}
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputWorkloadOrder(ctx context.Context, obj any) (workload.WorkloadOrder, error) {
 	var it workload.WorkloadOrder
 	if obj == nil {
@@ -1498,6 +1535,11 @@ func (ec *executionContext) marshalNEnvironmentWorkloadOrderField2githubᚗcom�
 	return v
 }
 
+func (ec *executionContext) unmarshalNUpdateEnvVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInput(ctx context.Context, v any) (*workload.UpdateEnvVariableInput, error) {
+	res, err := ec.unmarshalInputUpdateEnvVariableInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNValueEncoding2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋsecretᚐValueEncoding(ctx context.Context, v any) (secret.ValueEncoding, error) {
 	var res secret.ValueEncoding
 	err := res.UnmarshalGQL(v)
@@ -1602,6 +1644,24 @@ func (ec *executionContext) unmarshalOTeamWorkloadsFilter2ᚖgithubᚗcomᚋnais
 	}
 	res, err := ec.unmarshalInputTeamWorkloadsFilter(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOUpdateEnvVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInputᚄ(ctx context.Context, v any) ([]*workload.UpdateEnvVariableInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*workload.UpdateEnvVariableInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNUpdateEnvVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvVariableInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) unmarshalOValueEncoding2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋsecretᚐValueEncoding(ctx context.Context, v any) (*secret.ValueEncoding, error) {

--- a/internal/graph/gengql/workloads.generated.go
+++ b/internal/graph/gengql/workloads.generated.go
@@ -798,8 +798,8 @@ func (ec *executionContext) unmarshalInputTeamWorkloadsFilter(ctx context.Contex
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputUpdateEnvironmentVariableInput(ctx context.Context, obj any) (workload.UpdateEnvironmentVariableInput, error) {
-	var it workload.UpdateEnvironmentVariableInput
+func (ec *executionContext) unmarshalInputUpdateWorkloadEnvironmentVariableInput(ctx context.Context, obj any) (workload.UpdateWorkloadEnvironmentVariableInput, error) {
+	var it workload.UpdateWorkloadEnvironmentVariableInput
 	if obj == nil {
 		return it, nil
 	}
@@ -1535,8 +1535,8 @@ func (ec *executionContext) marshalNEnvironmentWorkloadOrderField2githubᚗcom�
 	return v
 }
 
-func (ec *executionContext) unmarshalNUpdateEnvironmentVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInput(ctx context.Context, v any) (*workload.UpdateEnvironmentVariableInput, error) {
-	res, err := ec.unmarshalInputUpdateEnvironmentVariableInput(ctx, v)
+func (ec *executionContext) unmarshalNUpdateWorkloadEnvironmentVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateWorkloadEnvironmentVariableInput(ctx context.Context, v any) (*workload.UpdateWorkloadEnvironmentVariableInput, error) {
+	res, err := ec.unmarshalInputUpdateWorkloadEnvironmentVariableInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
@@ -1646,17 +1646,17 @@ func (ec *executionContext) unmarshalOTeamWorkloadsFilter2ᚖgithubᚗcomᚋnais
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) unmarshalOUpdateEnvironmentVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInputᚄ(ctx context.Context, v any) ([]*workload.UpdateEnvironmentVariableInput, error) {
+func (ec *executionContext) unmarshalOUpdateWorkloadEnvironmentVariableInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateWorkloadEnvironmentVariableInputᚄ(ctx context.Context, v any) ([]*workload.UpdateWorkloadEnvironmentVariableInput, error) {
 	if v == nil {
 		return nil, nil
 	}
 	var vSlice []any
 	vSlice = graphql.CoerceList(v)
 	var err error
-	res := make([]*workload.UpdateEnvironmentVariableInput, len(vSlice))
+	res := make([]*workload.UpdateWorkloadEnvironmentVariableInput, len(vSlice))
 	for i := range vSlice {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNUpdateEnvironmentVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateEnvironmentVariableInput(ctx, vSlice[i])
+		res[i], err = ec.unmarshalNUpdateWorkloadEnvironmentVariableInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐUpdateWorkloadEnvironmentVariableInput(ctx, vSlice[i])
 		if err != nil {
 			return nil, err
 		}

--- a/internal/graph/jobs.resolvers.go
+++ b/internal/graph/jobs.resolvers.go
@@ -148,6 +148,14 @@ func (r *mutationResolver) TriggerJob(ctx context.Context, input job.TriggerJobI
 	}, nil
 }
 
+func (r *mutationResolver) UpdateJob(ctx context.Context, input job.UpdateJobInput) (*job.UpdateJobPayload, error) {
+	if err := authz.CanUpdateJobs(ctx, input.TeamSlug); err != nil {
+		return nil, err
+	}
+
+	return job.Update(ctx, input)
+}
+
 func (r *teamResolver) Jobs(ctx context.Context, obj *team.Team, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, orderBy *job.JobOrder, filter *job.TeamJobsFilter) (*job.JobConnection, error) {
 	page, err := pagination.ParsePage(first, after, last, before)
 	if err != nil {
@@ -198,6 +206,10 @@ func (r *triggerJobPayloadResolver) Job(ctx context.Context, obj *job.TriggerJob
 	return job.Get(ctx, obj.TeamSlug, obj.EnvironmentName, obj.JobName)
 }
 
+func (r *updateJobPayloadResolver) Job(ctx context.Context, obj *job.UpdateJobPayload) (*job.Job, error) {
+	return job.Get(ctx, obj.TeamSlug, obj.EnvironmentName, obj.JobName)
+}
+
 func (r *Resolver) DeleteJobPayload() gengql.DeleteJobPayloadResolver {
 	return &deleteJobPayloadResolver{r}
 }
@@ -216,6 +228,10 @@ func (r *Resolver) TriggerJobPayload() gengql.TriggerJobPayloadResolver {
 	return &triggerJobPayloadResolver{r}
 }
 
+func (r *Resolver) UpdateJobPayload() gengql.UpdateJobPayloadResolver {
+	return &updateJobPayloadResolver{r}
+}
+
 type (
 	deleteJobPayloadResolver    struct{ *Resolver }
 	deleteJobRunPayloadResolver struct{ *Resolver }
@@ -223,4 +239,5 @@ type (
 	jobConnectionResolver       struct{ *Resolver }
 	jobRunResolver              struct{ *Resolver }
 	triggerJobPayloadResolver   struct{ *Resolver }
+	updateJobPayloadResolver    struct{ *Resolver }
 )

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -67,6 +67,17 @@ extend type Mutation {
 		"""
 		input: RestartApplicationInput!
 	): RestartApplicationPayload!
+
+	"""
+	Update specific fields on an application. Only provided fields are applied.
+	Changes are temporary and will be overwritten on next deploy.
+	"""
+	updateApplication(
+		"""
+		Input for updating an application.
+		"""
+		input: UpdateApplicationInput!
+	): UpdateApplicationPayload!
 }
 
 extend type TeamInventoryCounts {
@@ -552,6 +563,58 @@ type RestartApplicationPayload {
 	application: Application
 }
 
+input UpdateApplicationInput {
+	"""
+	Name of the application.
+	"""
+	name: String!
+
+	"""
+	Slug of the team that owns the application.
+	"""
+	teamSlug: Slug!
+
+	"""
+	Name of the environment where the application runs.
+	"""
+	environmentName: String!
+
+	"""
+	Update environment variables. Variables are merged with existing ones.
+	"""
+	env: [UpdateEnvVariableInput!]
+
+	"""
+	Update the replica configuration.
+	"""
+	replicas: UpdateApplicationReplicasInput
+}
+
+"""
+Input for updating the replica configuration of an application.
+"""
+input UpdateApplicationReplicasInput {
+	"""
+	Minimum number of replicas.
+	"""
+	min: Int!
+
+	"""
+	Maximum number of replicas.
+	"""
+	max: Int!
+}
+
+"""
+Payload for updating an application.
+"""
+type UpdateApplicationPayload {
+	"""
+	The updated application.
+	"""
+	application: Application
+}
+
 type Ingress {
 	"""
 	URL for the ingress.
@@ -840,6 +903,13 @@ type ApplicationCreatedActivityLogEntry implements ActivityLogEntry & Node {
 	data: GenericKubernetesResourceActivityLogEntryData!
 }
 
+type ApplicationUpdatedActivityLogEntryData {
+	"The fields that changed during the update."
+	changedFields: [ResourceChangedField!]!
+	"GitHub Actions OIDC token claims at the time of the apply. Only present when the request was authenticated via a GitHub token."
+	gitHubActorClaims: GitHubActorClaims
+}
+
 type ApplicationUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	"ID of the entry."
 	id: ID!
@@ -866,7 +936,7 @@ type ApplicationUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	environmentName: String
 
 	"Data associated with the update."
-	data: GenericKubernetesResourceActivityLogEntryData!
+	data: ApplicationUpdatedActivityLogEntryData!
 }
 
 extend enum ActivityLogActivityType {
@@ -884,4 +954,9 @@ extend enum ActivityLogActivityType {
 	An application was scaled.
 	"""
 	APPLICATION_SCALED
+
+	"""
+	An application was updated.
+	"""
+	APPLICATION_UPDATED
 }

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -563,6 +563,9 @@ type RestartApplicationPayload {
 	application: Application
 }
 
+"""
+Input for updating an application.
+"""
 input UpdateApplicationInput {
 	"""
 	Name of the application.

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -582,7 +582,7 @@ input UpdateApplicationInput {
 	"""
 	Update environment variables. Variables are merged with existing ones.
 	"""
-	env: [UpdateEnvVariableInput!]
+	env: [UpdateEnvironmentVariableInput!]
 
 	"""
 	Update the replica configuration.
@@ -903,6 +903,9 @@ type ApplicationCreatedActivityLogEntry implements ActivityLogEntry & Node {
 	data: GenericKubernetesResourceActivityLogEntryData!
 }
 
+"""
+Data associated with an application update activity log entry.
+"""
 type ApplicationUpdatedActivityLogEntryData {
 	"The fields that changed during the update."
 	changedFields: [ResourceChangedField!]!
@@ -910,6 +913,9 @@ type ApplicationUpdatedActivityLogEntryData {
 	gitHubActorClaims: GitHubActorClaims
 }
 
+"""
+Activity log entry for when an application is updated.
+"""
 type ApplicationUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	"ID of the entry."
 	id: ID!

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -585,7 +585,7 @@ input UpdateApplicationInput {
 	"""
 	Update environment variables. Variables are merged with existing ones.
 	"""
-	env: [UpdateEnvironmentVariableInput!]
+	environmentVariables: [UpdateWorkloadEnvironmentVariableInput!]
 
 	"""
 	Update the replica configuration.

--- a/internal/graph/schema/apply.graphqls
+++ b/internal/graph/schema/apply.graphqls
@@ -1,7 +1,4 @@
 extend enum ActivityLogActivityType {
-	"A generic kubernetes resource was updated via apply."
-	GENERIC_KUBERNETES_RESOURCE_UPDATED
-
 	"A generic kubernetes resource was created via apply."
 	GENERIC_KUBERNETES_RESOURCE_CREATED
 }

--- a/internal/graph/schema/jobs.graphqls
+++ b/internal/graph/schema/jobs.graphqls
@@ -695,7 +695,7 @@ input UpdateJobInput {
 	"""
 	Update environment variables. Variables are merged with existing ones.
 	"""
-	env: [UpdateEnvVariableInput!]
+	env: [UpdateEnvironmentVariableInput!]
 }
 
 """

--- a/internal/graph/schema/jobs.graphqls
+++ b/internal/graph/schema/jobs.graphqls
@@ -626,6 +626,9 @@ type JobCreatedActivityLogEntry implements ActivityLogEntry & Node {
 	data: GenericKubernetesResourceActivityLogEntryData!
 }
 
+"""
+Activity log entry for when a job is updated.
+"""
 type JobUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	"ID of the entry."
 	id: ID!
@@ -655,6 +658,9 @@ type JobUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	data: JobUpdatedActivityLogEntryData!
 }
 
+"""
+Data associated with a job update activity log entry.
+"""
 type JobUpdatedActivityLogEntryData {
 	"The fields that changed during the update."
 	changedFields: [ResourceChangedField!]!

--- a/internal/graph/schema/jobs.graphqls
+++ b/internal/graph/schema/jobs.graphqls
@@ -701,7 +701,7 @@ input UpdateJobInput {
 	"""
 	Update environment variables. Variables are merged with existing ones.
 	"""
-	env: [UpdateEnvironmentVariableInput!]
+	environmentVariables: [UpdateWorkloadEnvironmentVariableInput!]
 }
 
 """

--- a/internal/graph/schema/jobs.graphqls
+++ b/internal/graph/schema/jobs.graphqls
@@ -30,6 +30,17 @@ extend type Mutation {
 
 	"Trigger a job"
 	triggerJob(input: TriggerJobInput!): TriggerJobPayload!
+
+	"""
+	Update specific fields on a job. Only provided fields are applied.
+	Changes are temporary and will be overwritten on next deploy.
+	"""
+	updateJob(
+		"""
+		Input for updating a job.
+		"""
+		input: UpdateJobInput!
+	): UpdateJobPayload!
 }
 
 extend type TeamEnvironment {
@@ -641,7 +652,14 @@ type JobUpdatedActivityLogEntry implements ActivityLogEntry & Node {
 	environmentName: String
 
 	"Data associated with the update."
-	data: GenericKubernetesResourceActivityLogEntryData!
+	data: JobUpdatedActivityLogEntryData!
+}
+
+type JobUpdatedActivityLogEntryData {
+	"The fields that changed during the update."
+	changedFields: [ResourceChangedField!]!
+	"GitHub Actions OIDC token claims at the time of the apply. Only present when the request was authenticated via a GitHub token."
+	gitHubActorClaims: GitHubActorClaims
 }
 
 extend enum ActivityLogActivityType {
@@ -653,4 +671,39 @@ extend enum ActivityLogActivityType {
 
 	"Activity log entries related to job triggering."
 	JOB_TRIGGERED
+
+	"Activity log entries related to job updates."
+	JOB_UPDATED
+}
+
+input UpdateJobInput {
+	"""
+	Name of the job.
+	"""
+	name: String!
+
+	"""
+	Slug of the team that owns the job.
+	"""
+	teamSlug: Slug!
+
+	"""
+	Name of the environment where the job runs.
+	"""
+	environmentName: String!
+
+	"""
+	Update environment variables. Variables are merged with existing ones.
+	"""
+	env: [UpdateEnvVariableInput!]
+}
+
+"""
+Payload for updating a job.
+"""
+type UpdateJobPayload {
+	"""
+	The updated job.
+	"""
+	job: Job
 }

--- a/internal/graph/schema/workloads.graphqls
+++ b/internal/graph/schema/workloads.graphqls
@@ -459,7 +459,7 @@ input TeamWorkloadsFilter {
 """
 Input for setting an environment variable on a workload. To remove a variable, set value to null.
 """
-input UpdateEnvVariableInput {
+input UpdateEnvironmentVariableInput {
 	"""
 	Name of the environment variable.
 	"""

--- a/internal/graph/schema/workloads.graphqls
+++ b/internal/graph/schema/workloads.graphqls
@@ -459,7 +459,7 @@ input TeamWorkloadsFilter {
 """
 Input for setting an environment variable on a workload. To remove a variable, set value to null.
 """
-input UpdateEnvironmentVariableInput {
+input UpdateWorkloadEnvironmentVariableInput {
 	"""
 	Name of the environment variable.
 	"""

--- a/internal/graph/schema/workloads.graphqls
+++ b/internal/graph/schema/workloads.graphqls
@@ -455,3 +455,18 @@ input TeamWorkloadsFilter {
 	"""
 	environments: [String!]
 }
+
+"""
+Input for setting an environment variable on a workload. To remove a variable, set value to null.
+"""
+input UpdateEnvVariableInput {
+	"""
+	Name of the environment variable.
+	"""
+	name: String!
+
+	"""
+	Value of the environment variable. Set to null to remove the variable.
+	"""
+	value: String
+}

--- a/internal/workload/application/activitylog.go
+++ b/internal/workload/application/activitylog.go
@@ -66,7 +66,7 @@ func init() {
 				Data:                    data,
 			}, nil
 		case activitylog.ActivityLogEntryActionUpdated:
-			data, err := activitylog.UnmarshalData[activitylog.GenericKubernetesResourceActivityLogEntryData](entry)
+			data, err := activitylog.UnmarshalData[ApplicationUpdatedActivityLogEntryData](entry)
 			if err != nil {
 				return nil, fmt.Errorf("transforming application updated activity log entry data: %w", err)
 			}
@@ -85,6 +85,7 @@ func init() {
 	activitylog.RegisterFilter("DEPLOYMENT", deploymentactivity.ActivityLogEntryActionDeployment, ActivityLogEntryResourceTypeApplication)
 	activitylog.RegisterFilter("GENERIC_KUBERNETES_RESOURCE_CREATED", activitylog.ActivityLogEntryActionCreated, ActivityLogEntryResourceTypeApplication)
 	activitylog.RegisterFilter("GENERIC_KUBERNETES_RESOURCE_UPDATED", activitylog.ActivityLogEntryActionUpdated, ActivityLogEntryResourceTypeApplication)
+	activitylog.RegisterFilter("APPLICATION_UPDATED", activitylog.ActivityLogEntryActionUpdated, ActivityLogEntryResourceTypeApplication)
 }
 
 type ApplicationRestartedActivityLogEntry struct {
@@ -115,5 +116,10 @@ type ApplicationCreatedActivityLogEntry struct {
 type ApplicationUpdatedActivityLogEntry struct {
 	activitylog.GenericActivityLogEntry
 
-	Data *activitylog.GenericKubernetesResourceActivityLogEntryData `json:"data"`
+	Data *ApplicationUpdatedActivityLogEntryData `json:"data"`
+}
+
+type ApplicationUpdatedActivityLogEntryData struct {
+	ChangedFields     []*activitylog.ResourceChangedField `json:"changedFields"`
+	GitHubActorClaims *activitylog.GitHubActorClaims      `json:"gitHubActorClaims,omitempty"`
 }

--- a/internal/workload/application/activitylog.go
+++ b/internal/workload/application/activitylog.go
@@ -84,7 +84,6 @@ func init() {
 	activitylog.RegisterFilter("APPLICATION_SCALED", activityLogEntryActionAutoScaleApplication, ActivityLogEntryResourceTypeApplication)
 	activitylog.RegisterFilter("DEPLOYMENT", deploymentactivity.ActivityLogEntryActionDeployment, ActivityLogEntryResourceTypeApplication)
 	activitylog.RegisterFilter("GENERIC_KUBERNETES_RESOURCE_CREATED", activitylog.ActivityLogEntryActionCreated, ActivityLogEntryResourceTypeApplication)
-	activitylog.RegisterFilter("GENERIC_KUBERNETES_RESOURCE_UPDATED", activitylog.ActivityLogEntryActionUpdated, ActivityLogEntryResourceTypeApplication)
 	activitylog.RegisterFilter("APPLICATION_UPDATED", activitylog.ActivityLogEntryActionUpdated, ActivityLogEntryResourceTypeApplication)
 }
 

--- a/internal/workload/application/models.go
+++ b/internal/workload/application/models.go
@@ -531,11 +531,11 @@ type RestartApplicationPayload struct {
 }
 
 type UpdateApplicationInput struct {
-	Name            string                             `json:"name"`
-	TeamSlug        slug.Slug                          `json:"teamSlug"`
-	EnvironmentName string                             `json:"environmentName"`
-	Env             []*workload.UpdateEnvVariableInput `json:"env,omitempty"`
-	Replicas        *UpdateApplicationReplicasInput    `json:"replicas,omitempty"`
+	Name            string                                     `json:"name"`
+	TeamSlug        slug.Slug                                  `json:"teamSlug"`
+	EnvironmentName string                                     `json:"environmentName"`
+	Env             []*workload.UpdateEnvironmentVariableInput `json:"env,omitempty"`
+	Replicas        *UpdateApplicationReplicasInput            `json:"replicas,omitempty"`
 }
 
 type UpdateApplicationReplicasInput struct {

--- a/internal/workload/application/models.go
+++ b/internal/workload/application/models.go
@@ -530,6 +530,25 @@ type RestartApplicationPayload struct {
 	EnvironmentName string    `json:"-"`
 }
 
+type UpdateApplicationInput struct {
+	Name            string                             `json:"name"`
+	TeamSlug        slug.Slug                          `json:"teamSlug"`
+	EnvironmentName string                             `json:"environmentName"`
+	Env             []*workload.UpdateEnvVariableInput `json:"env,omitempty"`
+	Replicas        *UpdateApplicationReplicasInput    `json:"replicas,omitempty"`
+}
+
+type UpdateApplicationReplicasInput struct {
+	Min int `json:"min"`
+	Max int `json:"max"`
+}
+
+type UpdateApplicationPayload struct {
+	TeamSlug        slug.Slug `json:"-"`
+	ApplicationName string    `json:"-"`
+	EnvironmentName string    `json:"-"`
+}
+
 type ApplicationInstanceState string
 
 const (

--- a/internal/workload/application/models.go
+++ b/internal/workload/application/models.go
@@ -531,11 +531,11 @@ type RestartApplicationPayload struct {
 }
 
 type UpdateApplicationInput struct {
-	Name            string                                     `json:"name"`
-	TeamSlug        slug.Slug                                  `json:"teamSlug"`
-	EnvironmentName string                                     `json:"environmentName"`
-	Env             []*workload.UpdateEnvironmentVariableInput `json:"env,omitempty"`
-	Replicas        *UpdateApplicationReplicasInput            `json:"replicas,omitempty"`
+	Name                 string                                             `json:"name"`
+	TeamSlug             slug.Slug                                          `json:"teamSlug"`
+	EnvironmentName      string                                             `json:"environmentName"`
+	EnvironmentVariables []*workload.UpdateWorkloadEnvironmentVariableInput `json:"environmentVariables,omitempty"`
+	Replicas             *UpdateApplicationReplicasInput                    `json:"replicas,omitempty"`
 }
 
 type UpdateApplicationReplicasInput struct {

--- a/internal/workload/application/queries.go
+++ b/internal/workload/application/queries.go
@@ -173,8 +173,8 @@ func Update(ctx context.Context, input UpdateApplicationInput) (*UpdateApplicati
 
 	var changedFields []*activitylog.ResourceChangedField
 
-	if input.Env != nil {
-		merged := workload.MergeEnvVars(app.Spec.Env, input.Env)
+	if len(input.EnvironmentVariables) > 0 {
+		merged := workload.MergeEnvVars(app.Spec.Env, input.EnvironmentVariables)
 		if !workload.EnvVarsEqual(app.Spec.Env, merged) {
 			changedFields = append(changedFields, workload.EnvVarChangedFields(app.Spec.Env, merged)...)
 			app.Spec.Env = merged

--- a/internal/workload/application/queries.go
+++ b/internal/workload/application/queries.go
@@ -192,14 +192,20 @@ func Update(ctx context.Context, input UpdateApplicationInput) (*UpdateApplicati
 				app.Spec.Replicas = &nais_io_v1.Replicas{}
 			} else {
 				if !ptr.Equal(app.Spec.Replicas.Min, &min) {
-					oldMin := strconv.Itoa(*app.Spec.Replicas.Min)
+					var oldMin *string
+					if app.Spec.Replicas.Min != nil {
+						oldMin = new(strconv.Itoa(*app.Spec.Replicas.Min))
+					}
 					newMin := strconv.Itoa(min)
-					changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.replicas.min", OldValue: &oldMin, NewValue: &newMin})
+					changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.replicas.min", OldValue: oldMin, NewValue: &newMin})
 				}
 				if !ptr.Equal(app.Spec.Replicas.Max, &max) {
-					oldMax := strconv.Itoa(*app.Spec.Replicas.Max)
+					var oldMax *string
+					if app.Spec.Replicas.Max != nil {
+						oldMax = new(strconv.Itoa(*app.Spec.Replicas.Max))
+					}
 					newMax := strconv.Itoa(max)
-					changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.replicas.max", OldValue: &oldMax, NewValue: &newMax})
+					changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.replicas.max", OldValue: oldMax, NewValue: &newMax})
 				}
 			}
 			app.Spec.Replicas.Min = &min

--- a/internal/workload/application/queries.go
+++ b/internal/workload/application/queries.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/nais/api/internal/activitylog"
@@ -14,8 +15,11 @@ import (
 	"github.com/nais/api/internal/kubernetes/watcher"
 	"github.com/nais/api/internal/slug"
 	"github.com/nais/api/internal/workload"
+	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
@@ -157,6 +161,93 @@ func Restart(ctx context.Context, teamSlug slug.Slug, environmentName, name stri
 		ResourceName:    name,
 		Actor:           authz.ActorFromContext(ctx).User,
 	})
+}
+
+func Update(ctx context.Context, input UpdateApplicationInput) (*UpdateApplicationPayload, error) {
+	w := fromContext(ctx).appWatcher
+
+	app, err := w.Get(input.EnvironmentName, input.TeamSlug.String(), input.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	var changedFields []*activitylog.ResourceChangedField
+
+	if input.Env != nil {
+		merged := workload.MergeEnvVars(app.Spec.Env, input.Env)
+		if !workload.EnvVarsEqual(app.Spec.Env, merged) {
+			changedFields = append(changedFields, workload.EnvVarChangedFields(app.Spec.Env, merged)...)
+			app.Spec.Env = merged
+		}
+	}
+
+	if input.Replicas != nil {
+		min, max := input.Replicas.Min, input.Replicas.Max
+		if app.Spec.Replicas == nil || !ptr.Equal(app.Spec.Replicas.Min, &min) || !ptr.Equal(app.Spec.Replicas.Max, &max) {
+			if app.Spec.Replicas == nil {
+				minStr := strconv.Itoa(min)
+				maxStr := strconv.Itoa(max)
+				changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.replicas.min", NewValue: &minStr})
+				changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.replicas.max", NewValue: &maxStr})
+				app.Spec.Replicas = &nais_io_v1.Replicas{}
+			} else {
+				if !ptr.Equal(app.Spec.Replicas.Min, &min) {
+					oldMin := strconv.Itoa(*app.Spec.Replicas.Min)
+					newMin := strconv.Itoa(min)
+					changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.replicas.min", OldValue: &oldMin, NewValue: &newMin})
+				}
+				if !ptr.Equal(app.Spec.Replicas.Max, &max) {
+					oldMax := strconv.Itoa(*app.Spec.Replicas.Max)
+					newMax := strconv.Itoa(max)
+					changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.replicas.max", OldValue: &oldMax, NewValue: &newMax})
+				}
+			}
+			app.Spec.Replicas.Min = &min
+			app.Spec.Replicas.Max = &max
+		}
+	}
+
+	if len(changedFields) == 0 {
+		return &UpdateApplicationPayload{
+			TeamSlug:        input.TeamSlug,
+			EnvironmentName: input.EnvironmentName,
+			ApplicationName: input.Name,
+		}, nil
+	}
+
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(app)
+	if err != nil {
+		return nil, fmt.Errorf("converting application to unstructured: %w", err)
+	}
+
+	client, err := w.ImpersonatedClient(ctx, input.EnvironmentName)
+	if err != nil {
+		return nil, fmt.Errorf("creating impersonated client: %w", err)
+	}
+
+	if _, err := client.Namespace(input.TeamSlug.String()).Update(ctx, &unstructured.Unstructured{Object: obj}, metav1.UpdateOptions{}); err != nil {
+		return nil, fmt.Errorf("updating application: %w", err)
+	}
+
+	if err := activitylog.Create(ctx, activitylog.CreateInput{
+		Action:          activitylog.ActivityLogEntryActionUpdated,
+		ResourceType:    ActivityLogEntryResourceTypeApplication,
+		TeamSlug:        &input.TeamSlug,
+		EnvironmentName: &input.EnvironmentName,
+		ResourceName:    input.Name,
+		Actor:           authz.ActorFromContext(ctx).User,
+		Data: &ApplicationUpdatedActivityLogEntryData{
+			ChangedFields: changedFields,
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	return &UpdateApplicationPayload{
+		TeamSlug:        input.TeamSlug,
+		EnvironmentName: input.EnvironmentName,
+		ApplicationName: input.Name,
+	}, nil
 }
 
 func ListInstances(ctx context.Context, teamSlug slug.Slug, environmentName, appName string, page *pagination.Pagination) (*ApplicationInstanceConnection, error) {

--- a/internal/workload/job/activitylog.go
+++ b/internal/workload/job/activitylog.go
@@ -81,7 +81,6 @@ func init() {
 	activitylog.RegisterFilter("JOB_TRIGGERED", activityLogEntryActionTriggerJob, ActivityLogEntryResourceTypeJob)
 	activitylog.RegisterFilter("DEPLOYMENT", deploymentactivity.ActivityLogEntryActionDeployment, ActivityLogEntryResourceTypeJob)
 	activitylog.RegisterFilter("GENERIC_KUBERNETES_RESOURCE_CREATED", activitylog.ActivityLogEntryActionCreated, ActivityLogEntryResourceTypeJob)
-	activitylog.RegisterFilter("GENERIC_KUBERNETES_RESOURCE_UPDATED", activitylog.ActivityLogEntryActionUpdated, ActivityLogEntryResourceTypeJob)
 	activitylog.RegisterFilter("JOB_UPDATED", activitylog.ActivityLogEntryActionUpdated, ActivityLogEntryResourceTypeJob)
 }
 

--- a/internal/workload/job/activitylog.go
+++ b/internal/workload/job/activitylog.go
@@ -63,7 +63,7 @@ func init() {
 				Data:                    data,
 			}, nil
 		case activitylog.ActivityLogEntryActionUpdated:
-			data, err := activitylog.UnmarshalData[activitylog.GenericKubernetesResourceActivityLogEntryData](entry)
+			data, err := activitylog.UnmarshalData[JobUpdatedActivityLogEntryData](entry)
 			if err != nil {
 				return nil, fmt.Errorf("transforming job updated activity log entry data: %w", err)
 			}
@@ -82,6 +82,7 @@ func init() {
 	activitylog.RegisterFilter("DEPLOYMENT", deploymentactivity.ActivityLogEntryActionDeployment, ActivityLogEntryResourceTypeJob)
 	activitylog.RegisterFilter("GENERIC_KUBERNETES_RESOURCE_CREATED", activitylog.ActivityLogEntryActionCreated, ActivityLogEntryResourceTypeJob)
 	activitylog.RegisterFilter("GENERIC_KUBERNETES_RESOURCE_UPDATED", activitylog.ActivityLogEntryActionUpdated, ActivityLogEntryResourceTypeJob)
+	activitylog.RegisterFilter("JOB_UPDATED", activitylog.ActivityLogEntryActionUpdated, ActivityLogEntryResourceTypeJob)
 }
 
 type JobTriggeredActivityLogEntry struct {
@@ -110,5 +111,10 @@ type JobCreatedActivityLogEntry struct {
 type JobUpdatedActivityLogEntry struct {
 	activitylog.GenericActivityLogEntry
 
-	Data *activitylog.GenericKubernetesResourceActivityLogEntryData `json:"data"`
+	Data *JobUpdatedActivityLogEntryData `json:"data"`
+}
+
+type JobUpdatedActivityLogEntryData struct {
+	ChangedFields     []*activitylog.ResourceChangedField `json:"changedFields"`
+	GitHubActorClaims *activitylog.GitHubActorClaims      `json:"gitHubActorClaims,omitempty"`
 }

--- a/internal/workload/job/models.go
+++ b/internal/workload/job/models.go
@@ -492,10 +492,10 @@ type TriggerJobPayload struct {
 }
 
 type UpdateJobInput struct {
-	Name            string                             `json:"name"`
-	TeamSlug        slug.Slug                          `json:"teamSlug"`
-	EnvironmentName string                             `json:"environmentName"`
-	Env             []*workload.UpdateEnvVariableInput `json:"env,omitempty"`
+	Name            string                                     `json:"name"`
+	TeamSlug        slug.Slug                                  `json:"teamSlug"`
+	EnvironmentName string                                     `json:"environmentName"`
+	Env             []*workload.UpdateEnvironmentVariableInput `json:"env,omitempty"`
 }
 
 type UpdateJobPayload struct {

--- a/internal/workload/job/models.go
+++ b/internal/workload/job/models.go
@@ -492,10 +492,10 @@ type TriggerJobPayload struct {
 }
 
 type UpdateJobInput struct {
-	Name            string                                     `json:"name"`
-	TeamSlug        slug.Slug                                  `json:"teamSlug"`
-	EnvironmentName string                                     `json:"environmentName"`
-	Env             []*workload.UpdateEnvironmentVariableInput `json:"env,omitempty"`
+	Name                 string                                             `json:"name"`
+	TeamSlug             slug.Slug                                          `json:"teamSlug"`
+	EnvironmentName      string                                             `json:"environmentName"`
+	EnvironmentVariables []*workload.UpdateWorkloadEnvironmentVariableInput `json:"environmentVariables,omitempty"`
 }
 
 type UpdateJobPayload struct {

--- a/internal/workload/job/models.go
+++ b/internal/workload/job/models.go
@@ -491,6 +491,19 @@ type TriggerJobPayload struct {
 	JobRun          *JobRun   `json:"jobRun"`
 }
 
+type UpdateJobInput struct {
+	Name            string                             `json:"name"`
+	TeamSlug        slug.Slug                          `json:"teamSlug"`
+	EnvironmentName string                             `json:"environmentName"`
+	Env             []*workload.UpdateEnvVariableInput `json:"env,omitempty"`
+}
+
+type UpdateJobPayload struct {
+	TeamSlug        slug.Slug `json:"-"`
+	JobName         string    `json:"-"`
+	EnvironmentName string    `json:"-"`
+}
+
 func statusMessage(job *batchv1.Job) string {
 	if failedTime(job) != nil {
 		return fmt.Sprintf("Run failed after %d attempts", job.Status.Failed)

--- a/internal/workload/job/queries.go
+++ b/internal/workload/job/queries.go
@@ -270,6 +270,67 @@ func Trigger(ctx context.Context, teamSlug slug.Slug, environmentName, name, run
 	return ToGraphJobRun(jobRunBatch, environmentName), nil
 }
 
+func Update(ctx context.Context, input UpdateJobInput) (*UpdateJobPayload, error) {
+	w := fromContext(ctx).jobWatcher
+
+	naisjob, err := w.Get(input.EnvironmentName, input.TeamSlug.String(), input.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	var changedFields []*activitylog.ResourceChangedField
+
+	if input.Env != nil {
+		merged := workload.MergeEnvVars(naisjob.Spec.Env, input.Env)
+		if !workload.EnvVarsEqual(naisjob.Spec.Env, merged) {
+			changedFields = append(changedFields, workload.EnvVarChangedFields(naisjob.Spec.Env, merged)...)
+			naisjob.Spec.Env = merged
+		}
+	}
+
+	if len(changedFields) == 0 {
+		return &UpdateJobPayload{
+			TeamSlug:        input.TeamSlug,
+			JobName:         input.Name,
+			EnvironmentName: input.EnvironmentName,
+		}, nil
+	}
+
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(naisjob)
+	if err != nil {
+		return nil, fmt.Errorf("converting naisjob to unstructured: %w", err)
+	}
+
+	client, err := w.ImpersonatedClient(ctx, input.EnvironmentName)
+	if err != nil {
+		return nil, fmt.Errorf("creating impersonated client: %w", err)
+	}
+
+	if _, err := client.Namespace(input.TeamSlug.String()).Update(ctx, &unstructured.Unstructured{Object: obj}, metav1.UpdateOptions{}); err != nil {
+		return nil, fmt.Errorf("updating job: %w", err)
+	}
+
+	if err := activitylog.Create(ctx, activitylog.CreateInput{
+		Action:          activitylog.ActivityLogEntryActionUpdated,
+		ResourceType:    ActivityLogEntryResourceTypeJob,
+		TeamSlug:        &input.TeamSlug,
+		EnvironmentName: &input.EnvironmentName,
+		ResourceName:    input.Name,
+		Actor:           authz.ActorFromContext(ctx).User,
+		Data: &JobUpdatedActivityLogEntryData{
+			ChangedFields: changedFields,
+		},
+	}); err != nil {
+		return nil, err
+	}
+
+	return &UpdateJobPayload{
+		TeamSlug:        input.TeamSlug,
+		JobName:         input.Name,
+		EnvironmentName: input.EnvironmentName,
+	}, nil
+}
+
 func GetState(ctx context.Context, obj *Job) (JobState, error) {
 	runs, err := allRuns(ctx, obj.GetTeamSlug(), obj.GetEnvironmentName(), obj.GetName())
 	if err != nil {

--- a/internal/workload/job/queries.go
+++ b/internal/workload/job/queries.go
@@ -280,8 +280,8 @@ func Update(ctx context.Context, input UpdateJobInput) (*UpdateJobPayload, error
 
 	var changedFields []*activitylog.ResourceChangedField
 
-	if input.Env != nil {
-		merged := workload.MergeEnvVars(naisjob.Spec.Env, input.Env)
+	if len(input.EnvironmentVariables) > 0 {
+		merged := workload.MergeEnvVars(naisjob.Spec.Env, input.EnvironmentVariables)
 		if !workload.EnvVarsEqual(naisjob.Spec.Env, merged) {
 			changedFields = append(changedFields, workload.EnvVarChangedFields(naisjob.Spec.Env, merged)...)
 			naisjob.Spec.Env = merged

--- a/internal/workload/models.go
+++ b/internal/workload/models.go
@@ -279,12 +279,12 @@ type TeamWorkloadsFilter struct {
 	WorkloadStatusErrorTypes []string `json:"workloadStatusErrorTypes,omitempty"`
 }
 
-type UpdateEnvironmentVariableInput struct {
+type UpdateWorkloadEnvironmentVariableInput struct {
 	Name  string  `json:"name"`
 	Value *string `json:"value,omitempty"`
 }
 
-func MergeEnvVars(existing nais_io_v1.EnvVars, updates []*UpdateEnvironmentVariableInput) nais_io_v1.EnvVars {
+func MergeEnvVars(existing nais_io_v1.EnvVars, updates []*UpdateWorkloadEnvironmentVariableInput) nais_io_v1.EnvVars {
 	envMap := make(map[string]nais_io_v1.EnvVar, len(existing))
 	for _, e := range existing {
 		envMap[e.Name] = e
@@ -354,6 +354,10 @@ func EnvVarChangedFields(existing nais_io_v1.EnvVars, merged nais_io_v1.EnvVars)
 			fields = append(fields, &activitylog.ResourceChangedField{Field: "spec.env." + name, NewValue: &n})
 		}
 	}
+
+	slices.SortFunc(fields, func(a, b *activitylog.ResourceChangedField) int {
+		return strings.Compare(a.Field, b.Field)
+	})
 
 	return fields
 }

--- a/internal/workload/models.go
+++ b/internal/workload/models.go
@@ -3,6 +3,7 @@ package workload
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -278,12 +279,12 @@ type TeamWorkloadsFilter struct {
 	WorkloadStatusErrorTypes []string `json:"workloadStatusErrorTypes,omitempty"`
 }
 
-type UpdateEnvVariableInput struct {
+type UpdateEnvironmentVariableInput struct {
 	Name  string  `json:"name"`
 	Value *string `json:"value,omitempty"`
 }
 
-func MergeEnvVars(existing nais_io_v1.EnvVars, updates []*UpdateEnvVariableInput) nais_io_v1.EnvVars {
+func MergeEnvVars(existing nais_io_v1.EnvVars, updates []*UpdateEnvironmentVariableInput) nais_io_v1.EnvVars {
 	envMap := make(map[string]nais_io_v1.EnvVar, len(existing))
 	for _, e := range existing {
 		envMap[e.Name] = e
@@ -301,6 +302,10 @@ func MergeEnvVars(existing nais_io_v1.EnvVars, updates []*UpdateEnvVariableInput
 	for _, v := range envMap {
 		result = append(result, v)
 	}
+
+	slices.SortFunc(result, func(a, b nais_io_v1.EnvVar) int {
+		return strings.Compare(a.Name, b.Name)
+	})
 	return result
 }
 

--- a/internal/workload/models.go
+++ b/internal/workload/models.go
@@ -277,3 +277,78 @@ type TeamWorkloadsFilter struct {
 	States                   []string `json:"states,omitempty"`
 	WorkloadStatusErrorTypes []string `json:"workloadStatusErrorTypes,omitempty"`
 }
+
+type UpdateEnvVariableInput struct {
+	Name  string  `json:"name"`
+	Value *string `json:"value,omitempty"`
+}
+
+func MergeEnvVars(existing nais_io_v1.EnvVars, updates []*UpdateEnvVariableInput) nais_io_v1.EnvVars {
+	envMap := make(map[string]nais_io_v1.EnvVar, len(existing))
+	for _, e := range existing {
+		envMap[e.Name] = e
+	}
+
+	for _, u := range updates {
+		if u.Value == nil {
+			delete(envMap, u.Name)
+		} else {
+			envMap[u.Name] = nais_io_v1.EnvVar{Name: u.Name, Value: *u.Value}
+		}
+	}
+
+	result := make(nais_io_v1.EnvVars, 0, len(envMap))
+	for _, v := range envMap {
+		result = append(result, v)
+	}
+	return result
+}
+
+func EnvVarsEqual(a, b nais_io_v1.EnvVars) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	m := make(map[string]string, len(a))
+	for _, v := range a {
+		m[v.Name] = v.Value
+	}
+	for _, v := range b {
+		if existing, ok := m[v.Name]; !ok || existing != v.Value {
+			return false
+		}
+	}
+	return true
+}
+
+func EnvVarChangedFields(existing nais_io_v1.EnvVars, merged nais_io_v1.EnvVars) []*activitylog.ResourceChangedField {
+	oldMap := make(map[string]string, len(existing))
+	for _, v := range existing {
+		oldMap[v.Name] = v.Value
+	}
+	newMap := make(map[string]string, len(merged))
+	for _, v := range merged {
+		newMap[v.Name] = v.Value
+	}
+
+	var fields []*activitylog.ResourceChangedField
+
+	for name, oldVal := range oldMap {
+		if newVal, ok := newMap[name]; !ok {
+			old := oldVal
+			fields = append(fields, &activitylog.ResourceChangedField{Field: "spec.env." + name, OldValue: &old})
+		} else if newVal != oldVal {
+			old := oldVal
+			n := newVal
+			fields = append(fields, &activitylog.ResourceChangedField{Field: "spec.env." + name, OldValue: &old, NewValue: &n})
+		}
+	}
+
+	for name, newVal := range newMap {
+		if _, ok := oldMap[name]; !ok {
+			n := newVal
+			fields = append(fields, &activitylog.ResourceChangedField{Field: "spec.env." + name, NewValue: &n})
+		}
+	}
+
+	return fields
+}


### PR DESCRIPTION
Implement GraphQL mutations for ad-hoc updates to Application (env + replicas) and Naisjob (env) resources. Includes per-field activity log tracking with old/new values, no-op detection, and integration tests.

---

Vi har gjort en bevisst breaking change, siden UpdateApplication og UpdateJob gir ikke mening å returnere som en "Generic kubernetes"-greie. Vi gjør heller at Apply også resulterer i en `ApplicationUpdate`-data struktur fremfor generic kubernetes for disse to ressursene. 

del av https://github.com/nais/system/pull/529