### PR TITLE
fix(vulnerability): return nil summary for NO_SBOM and FAILED SBOM states

### DIFF
--- a/internal/vulnerability/queries.go
+++ b/internal/vulnerability/queries.go
@@ -357,6 +357,13 @@ func GetImageVulnerabilitySummary(ctx context.Context, ref string) (*ImageVulner
 	if err != nil {
 		return nil, apierror.Errorf("get vulnerability summary: %v", err)
 	}
+
+	sbomStatus := sanitiseSbomStatus(SBOMStatus(resp.GetSbomStatus().GetStatus()))
+	switch sbomStatus {
+	case SBOMStatusNoSbom, SBOMStatusFailed:
+		return nil, nil
+	}
+
 	sum := resp.GetVulnerabilitySummary()
 	if sum == nil {
 		return nil, nil

--- a/internal/vulnerability/queries_test.go
+++ b/internal/vulnerability/queries_test.go
@@ -1,6 +1,86 @@
 package vulnerability
 
-import "testing"
+import (
+	"context"
+	"testing"
+
+	"github.com/nais/v13s/pkg/api/vulnerabilities"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type stubImageSummaryClient struct {
+	vulnerabilities.Client
+	status  vulnerabilities.SbomStatus
+	summary *vulnerabilities.Summary
+}
+
+func (s *stubImageSummaryClient) GetVulnerabilitySummaryForImage(_ context.Context, _, _ string) (*vulnerabilities.GetVulnerabilitySummaryForImageResponse, error) {
+	return &vulnerabilities.GetVulnerabilitySummaryForImageResponse{
+		SbomStatus:           &vulnerabilities.SbomStatusInfo{Status: s.status},
+		VulnerabilitySummary: s.summary,
+	}, nil
+}
+
+func (s *stubImageSummaryClient) Close() error { return nil }
+
+func newLoaderCtxWithStub(status vulnerabilities.SbomStatus, summary *vulnerabilities.Summary) context.Context {
+	mgr := &Manager{
+		Client: &stubImageSummaryClient{status: status, summary: summary},
+		log:    logrus.NewEntry(logrus.New()),
+	}
+	return NewLoaderContext(context.Background(), mgr, logrus.New())
+}
+
+func TestGetImageVulnerabilitySummary_SbomStatus(t *testing.T) {
+	staleTag := "2026.05.25-17.20-3f354bc"
+	staleSummary := &vulnerabilities.Summary{
+		Critical:      5,
+		High:          10,
+		StaleImageTag: &staleTag,
+	}
+
+	tests := []struct {
+		name    string
+		status  vulnerabilities.SbomStatus
+		wantNil bool
+	}{
+		{
+			name:    "NO_SBOM returns nil even with stale summary",
+			status:  vulnerabilities.SbomStatus_SBOM_STATUS_NO_SBOM,
+			wantNil: true,
+		},
+		{
+			name:    "FAILED returns nil even with stale summary",
+			status:  vulnerabilities.SbomStatus_SBOM_STATUS_FAILED,
+			wantNil: true,
+		},
+		{
+			name:    "PROCESSING returns stale summary",
+			status:  vulnerabilities.SbomStatus_SBOM_STATUS_PROCESSING,
+			wantNil: false,
+		},
+		{
+			name:    "READY returns summary",
+			status:  vulnerabilities.SbomStatus_SBOM_STATUS_READY,
+			wantNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := newLoaderCtxWithStub(tt.status, staleSummary)
+			got, err := GetImageVulnerabilitySummary(ctx, "myregistry.io/myimage:v1.0")
+			require.NoError(t, err)
+			if tt.wantNil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+			}
+		})
+	}
+}
 
 func TestSplitImage(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Workloads with `NO_SBOM` or `FAILED` SBOM status were returning stale vulnerability data from a previous image tag via the stale-tag fallback. This caused them to appear in the vulnerability list with real counts and affect sort order by risk score.

`GetImageVulnerabilitySummary` now returns `nil` for `NO_SBOM` and `FAILED` states. `PROCESSING` still returns stale data (intentional — bridges the gap while waiting for SBOM processing).