### PR TITLE
feat: add image field to updateApplication mutation

### DIFF
--- a/integration_tests/instance_groups.lua
+++ b/integration_tests/instance_groups.lua
@@ -340,3 +340,47 @@ Test.gql("Instance group with mounted files", function(t)
 		},
 	}
 end)
+
+Test.gql("Application history from ReplicaSets", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		query {
+			team(slug: "myteam") {
+				applications {
+					nodes {
+						name
+						history {
+							image
+							deployedAt
+						}
+					}
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			team = {
+				applications = {
+					nodes = {
+						{
+							name = "myapp",
+							history = {
+								{
+									image = "ghcr.io/navikt/myapp:v1.2.3",
+									deployedAt = "2024-01-15T10:00:00Z",
+								},
+								{
+									image = "ghcr.io/navikt/myapp:v1.0.0",
+									deployedAt = "2024-01-10T08:00:00Z",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)

--- a/integration_tests/k8s_resources/simple/dev/slug-1/another.yaml
+++ b/integration_tests/k8s_resources/simple/dev/slug-1/another.yaml
@@ -9,6 +9,8 @@ spec:
   replicas:
     max: 1
     min: 1
+status:
+  effectiveImage: navikt/app-name:latest
 
 ---
 apiVersion: apps/v1

--- a/integration_tests/k8s_resources/workload_image/dev/slug-1/app.yaml
+++ b/integration_tests/k8s_resources/workload_image/dev/slug-1/app.yaml
@@ -1,0 +1,21 @@
+apiVersion: nais.io/v1alpha1
+kind: Application
+metadata:
+  name: image-app
+spec:
+  image: ""
+  ingresses:
+    - "https://image-app.external.server.com"
+  replicas:
+    max: 2
+    min: 1
+status:
+  effectiveImage: ghcr.io/navikt/image-app:v1.0.0
+
+---
+apiVersion: nais.io/v1
+kind: Image
+metadata:
+  name: image-app
+spec:
+  image: ghcr.io/navikt/image-app:v1.0.0

--- a/integration_tests/update_application.lua
+++ b/integration_tests/update_application.lua
@@ -273,3 +273,128 @@ Test.gql("activity log contains env removal entry", function(t)
 		},
 	}
 end)
+
+Test.gql("update application image", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateApplication(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "another-app"
+					image: "navikt/app-name:v2.0.0"
+				}
+			) {
+				application {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateApplication = {
+				application = {
+					name = "another-app",
+				},
+			},
+		},
+	}
+end)
+
+Test.k8s("application has updated image", function(t)
+	t.check("nais.io/v1alpha1", "applications", "dev", "slug-1", "another-app", {
+		apiVersion = "nais.io/v1alpha1",
+		kind = "Application",
+		metadata = Ignore(),
+		spec = {
+			image = "navikt/app-name:v2.0.0",
+			ingresses = { "https://another-app.external.server.com" },
+			replicas = Ignore(),
+			env = {
+				{ name = "BAZ", value = "qux" },
+			},
+		},
+		status = Ignore(),
+	})
+end)
+
+Test.gql("activity log contains image update entry", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		{
+			team(slug: "%s") {
+				activityLog(first: 1, filter: { activityTypes: [APPLICATION_UPDATED] }) {
+					nodes {
+						__typename
+						resourceName
+						... on ApplicationUpdatedActivityLogEntry {
+							data {
+								changedFields {
+									field
+									oldValue
+									newValue
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]], team:slug()))
+
+	t.check {
+		data = {
+			team = {
+				activityLog = {
+					nodes = {
+						{
+							__typename = "ApplicationUpdatedActivityLogEntry",
+							resourceName = "another-app",
+							data = {
+								changedFields = {
+									{ field = "spec.image", oldValue = "navikt/app-name:latest", newValue = "navikt/app-name:v2.0.0" },
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("update application image no-op", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateApplication(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "another-app"
+					image: "navikt/app-name:v2.0.0"
+				}
+			) {
+				application {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateApplication = {
+				application = {
+					name = "another-app",
+				},
+			},
+		},
+	}
+end)

--- a/integration_tests/update_application_image.lua
+++ b/integration_tests/update_application_image.lua
@@ -1,0 +1,106 @@
+Helper.readK8sResources("k8s_resources/workload_image")
+
+local user = User.new()
+local team = Team.new("slug-1", "purpose", "#channel")
+team:addMember(user)
+
+Test.gql("update application image via Image resource when spec.image is empty", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateApplication(
+				input: {
+					teamSlug: "slug-1"
+					environmentName: "dev"
+					name: "image-app"
+					image: "ghcr.io/navikt/image-app:v2.0.0"
+				}
+			) {
+				application {
+					name
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateApplication = {
+				application = {
+					name = "image-app",
+				},
+			},
+		},
+	}
+end)
+
+Test.k8s("application spec.image remains empty", function(t)
+	t.check("nais.io/v1alpha1", "applications", "dev", "slug-1", "image-app", {
+		apiVersion = "nais.io/v1alpha1",
+		kind = "Application",
+		metadata = Ignore(),
+		spec = {
+			ingresses = { "https://image-app.external.server.com" },
+			replicas = Ignore(),
+		},
+		status = Ignore(),
+	})
+end)
+
+Test.k8s("Image resource is updated", function(t)
+	t.check("nais.io/v1", "images", "dev", "slug-1", "image-app", {
+		apiVersion = "nais.io/v1",
+		kind = "Image",
+		metadata = Ignore(),
+		spec = {
+			image = "ghcr.io/navikt/image-app:v2.0.0",
+		},
+	})
+end)
+
+Test.gql("activity log uses effectiveImage as old value", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		{
+			team(slug: "%s") {
+				activityLog(first: 1, filter: { activityTypes: [APPLICATION_UPDATED] }) {
+					nodes {
+						__typename
+						resourceName
+						... on ApplicationUpdatedActivityLogEntry {
+							data {
+								changedFields {
+									field
+									oldValue
+									newValue
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]], team:slug()))
+
+	t.check {
+		data = {
+			team = {
+				activityLog = {
+					nodes = {
+						{
+							__typename = "ApplicationUpdatedActivityLogEntry",
+							resourceName = "image-app",
+							data = {
+								changedFields = {
+									{ field = "spec.image", oldValue = "ghcr.io/navikt/image-app:v1.0.0", newValue = "ghcr.io/navikt/image-app:v2.0.0" },
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)

--- a/internal/graph/applications.resolvers.go
+++ b/internal/graph/applications.resolvers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nais/api/internal/team"
 	"github.com/nais/api/internal/workload"
 	"github.com/nais/api/internal/workload/application"
+	"github.com/nais/api/internal/workload/instancegroup"
 )
 
 func (r *applicationResolver) Team(ctx context.Context, obj *application.Application) (*team.Team, error) {
@@ -96,6 +97,10 @@ func (r *applicationResolver) Issues(ctx context.Context, obj *application.Appli
 	}
 
 	return issue.ListIssues(ctx, obj.TeamSlug, page, orderBy, f)
+}
+
+func (r *applicationResolver) History(ctx context.Context, obj *application.Application) ([]*instancegroup.ApplicationHistory, error) {
+	return instancegroup.ImageHistory(ctx, obj.TeamSlug, obj.EnvironmentName, obj.Name)
 }
 
 func (r *applicationConnectionResolver) Facets(ctx context.Context, obj *application.ApplicationConnection) (*application.ApplicationFacets, error) {

--- a/internal/graph/gengql/applications.generated.go
+++ b/internal/graph/gengql/applications.generated.go
@@ -4569,7 +4569,7 @@ func (ec *executionContext) unmarshalInputUpdateApplicationInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "teamSlug", "environmentName", "environmentVariables", "replicas"}
+	fieldsInOrder := [...]string{"name", "teamSlug", "environmentName", "environmentVariables", "replicas", "image"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -4611,6 +4611,13 @@ func (ec *executionContext) unmarshalInputUpdateApplicationInput(ctx context.Con
 				return it, err
 			}
 			it.Replicas = data
+		case "image":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("image"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Image = data
 		}
 	}
 	return it, nil

--- a/internal/graph/gengql/applications.generated.go
+++ b/internal/graph/gengql/applications.generated.go
@@ -55,6 +55,7 @@ type ApplicationResolver interface {
 	ActivityLog(ctx context.Context, obj *application.Application, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *activitylog.ActivityLogFilter) (*activitylog.ActivityLogEntryConnection, error)
 	State(ctx context.Context, obj *application.Application) (application.ApplicationState, error)
 	Issues(ctx context.Context, obj *application.Application, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, orderBy *issue.IssueOrder, filter *issue.ResourceIssueFilter) (*pagination.Connection[issue.Issue], error)
+	History(ctx context.Context, obj *application.Application) ([]*instancegroup.ApplicationHistory, error)
 	BigQueryDatasets(ctx context.Context, obj *application.Application, orderBy *bigquery.BigQueryDatasetOrder) (*pagination.Connection[*bigquery.BigQueryDataset], error)
 	Buckets(ctx context.Context, obj *application.Application, orderBy *bucket.BucketOrder) (*pagination.Connection[*bucket.Bucket], error)
 	Configs(ctx context.Context, obj *application.Application, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) (*pagination.Connection[*config.Config], error)
@@ -970,6 +971,38 @@ func (ec *executionContext) fieldContext_Application_issues(ctx context.Context,
 	if fc.Args, err = ec.field_Application_issues_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Application_history(ctx context.Context, field graphql.CollectedField, obj *application.Application) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Application_history(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Application().History(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*instancegroup.ApplicationHistory) graphql.Marshaler {
+			return ec.marshalNApplicationHistory2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋinstancegroupᚐApplicationHistoryᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Application_history(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Application",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_ApplicationHistory(ctx, field)
+		},
 	}
 	return fc, nil
 }
@@ -2373,6 +2406,52 @@ func (ec *executionContext) fieldContext_ApplicationFacets_states(_ context.Cont
 		},
 	}
 	return fc, nil
+}
+
+func (ec *executionContext) _ApplicationHistory_image(ctx context.Context, field graphql.CollectedField, obj *instancegroup.ApplicationHistory) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ApplicationHistory_image(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Image, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_ApplicationHistory_image(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ApplicationHistory", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _ApplicationHistory_deployedAt(ctx context.Context, field graphql.CollectedField, obj *instancegroup.ApplicationHistory) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ApplicationHistory_deployedAt(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.DeployedAt, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
+			return ec.marshalNTime2timeᚐTime(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_ApplicationHistory_deployedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ApplicationHistory", field, false, false, errors.New("field of type Time does not have child fields"))
 }
 
 func (ec *executionContext) _ApplicationInstance_id(ctx context.Context, field graphql.CollectedField, obj *application.ApplicationInstance) (ret graphql.Marshaler) {
@@ -5098,6 +5177,42 @@ func (ec *executionContext) _Application(ctx context.Context, sel ast.SelectionS
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "history":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Application_history(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "bigQueryDatasets":
 			field := field
 
@@ -6098,6 +6213,50 @@ func (ec *executionContext) _ApplicationFacets(ctx context.Context, sel ast.Sele
 			}
 		case "states":
 			out.Values[i] = ec._ApplicationFacets_states(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var applicationHistoryImplementors = []string{"ApplicationHistory"}
+
+func (ec *executionContext) _ApplicationHistory(ctx context.Context, sel ast.SelectionSet, obj *instancegroup.ApplicationHistory) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, applicationHistoryImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("ApplicationHistory")
+		case "image":
+			out.Values[i] = ec._ApplicationHistory_image(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "deployedAt":
+			out.Values[i] = ec._ApplicationHistory_deployedAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -7615,6 +7774,32 @@ func (ec *executionContext) marshalNApplicationEnvironmentFacetItem2ᚕgithubᚗ
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalNApplicationHistory2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋinstancegroupᚐApplicationHistoryᚄ(ctx context.Context, sel ast.SelectionSet, v []*instancegroup.ApplicationHistory) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNApplicationHistory2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋinstancegroupᚐApplicationHistory(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNApplicationHistory2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋinstancegroupᚐApplicationHistory(ctx context.Context, sel ast.SelectionSet, v *instancegroup.ApplicationHistory) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ApplicationHistory(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNApplicationInstance2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋapplicationᚐApplicationInstanceᚄ(ctx context.Context, sel ast.SelectionSet, v []*application.ApplicationInstance) graphql.Marshaler {

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -19571,7 +19571,7 @@ type Application implements Node & Workload & ActivityLogger {
 	): IssueConnection!
 
 	"""
-	History of previous deployments for this application, ordered by most recent first.
+	History of previous releases of this application, ordered by most recent first.
 	"""
 	history: [ApplicationHistory!]!
 }

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -19577,7 +19577,7 @@ type Application implements Node & Workload & ActivityLogger {
 }
 
 """
-A historical deployment entry for an application.
+A historical release entry for an application.
 """
 type ApplicationHistory {
 	"""

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -19882,6 +19882,11 @@ input UpdateApplicationInput {
 	Update the replica configuration.
 	"""
 	replicas: UpdateApplicationReplicasInput
+
+	"""
+	Update the container image. Must be a full image reference including tag, e.g. "ghcr.io/org/app:sha-abc123".
+	"""
+	image: String
 }
 
 """

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -230,6 +230,7 @@ type ComplexityRoot struct {
 		DeletionStartedAt         func(childComplexity int) int
 		Deployments               func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) int
 		Environment               func(childComplexity int) int
+		History                   func(childComplexity int) int
 		ID                        func(childComplexity int) int
 		Image                     func(childComplexity int) int
 		ImageVulnerabilityHistory func(childComplexity int, from scalar.Date) int
@@ -299,6 +300,11 @@ type ComplexityRoot struct {
 	ApplicationFacets struct {
 		Environments func(childComplexity int) int
 		States       func(childComplexity int) int
+	}
+
+	ApplicationHistory struct {
+		DeployedAt func(childComplexity int) int
+		Image      func(childComplexity int) int
 	}
 
 	ApplicationInstance struct {
@@ -3828,6 +3834,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Application.Environment(childComplexity), true
 
+	case "Application.history":
+		if e.ComplexityRoot.Application.History == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Application.History(childComplexity), true
+
 	case "Application.id":
 		if e.ComplexityRoot.Application.ID == nil {
 			break
@@ -4229,6 +4242,20 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.ApplicationFacets.States(childComplexity), true
+
+	case "ApplicationHistory.deployedAt":
+		if e.ComplexityRoot.ApplicationHistory.DeployedAt == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ApplicationHistory.DeployedAt(childComplexity), true
+
+	case "ApplicationHistory.image":
+		if e.ComplexityRoot.ApplicationHistory.Image == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ApplicationHistory.Image(childComplexity), true
 
 	case "ApplicationInstance.created":
 		if e.ComplexityRoot.ApplicationInstance.Created == nil {
@@ -19542,6 +19569,26 @@ type Application implements Node & Workload & ActivityLogger {
 		"Filtering options for items returned from the connection."
 		filter: ResourceIssueFilter
 	): IssueConnection!
+
+	"""
+	History of previous deployments for this application, ordered by most recent first.
+	"""
+	history: [ApplicationHistory!]!
+}
+
+"""
+A historical deployment entry for an application.
+"""
+type ApplicationHistory {
+	"""
+	The full container image reference including tag.
+	"""
+	image: String!
+
+	"""
+	When this image was deployed.
+	"""
+	deployedAt: Time!
 }
 
 enum ApplicationState {
@@ -31391,6 +31438,8 @@ func (ec *executionContext) childFields_Application(ctx context.Context, field g
 		return ec.fieldContext_Application_state(ctx, field)
 	case "issues":
 		return ec.fieldContext_Application_issues(ctx, field)
+	case "history":
+		return ec.fieldContext_Application_history(ctx, field)
 	case "bigQueryDatasets":
 		return ec.fieldContext_Application_bigQueryDatasets(ctx, field)
 	case "buckets":
@@ -31473,6 +31522,16 @@ func (ec *executionContext) childFields_ApplicationFacets(ctx context.Context, f
 		return ec.fieldContext_ApplicationFacets_states(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type ApplicationFacets", field.Name)
+}
+
+func (ec *executionContext) childFields_ApplicationHistory(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "image":
+		return ec.fieldContext_ApplicationHistory_image(ctx, field)
+	case "deployedAt":
+		return ec.fieldContext_ApplicationHistory_deployedAt(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type ApplicationHistory", field.Name)
 }
 
 func (ec *executionContext) childFields_ApplicationInstance(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -591,6 +591,11 @@ input UpdateApplicationInput {
 	Update the replica configuration.
 	"""
 	replicas: UpdateApplicationReplicasInput
+
+	"""
+	Update the container image. Must be a full image reference including tag, e.g. "ghcr.io/org/app:sha-abc123".
+	"""
+	image: String
 }
 
 """

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -251,6 +251,26 @@ type Application implements Node & Workload & ActivityLogger {
 		"Filtering options for items returned from the connection."
 		filter: ResourceIssueFilter
 	): IssueConnection!
+
+	"""
+	History of previous releases of this application, ordered by most recent first.
+	"""
+	history: [ApplicationHistory!]!
+}
+
+"""
+A historical deployment entry for an application.
+"""
+type ApplicationHistory {
+	"""
+	The full container image reference including tag.
+	"""
+	image: String!
+
+	"""
+	When this image was deployed.
+	"""
+	deployedAt: Time!
 }
 
 enum ApplicationState {

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -259,7 +259,7 @@ type Application implements Node & Workload & ActivityLogger {
 }
 
 """
-A historical deployment entry for an application.
+A historical release entry for an application.
 """
 type ApplicationHistory {
 	"""

--- a/internal/workload/application/models.go
+++ b/internal/workload/application/models.go
@@ -536,6 +536,7 @@ type UpdateApplicationInput struct {
 	EnvironmentName      string                                             `json:"environmentName"`
 	EnvironmentVariables []*workload.UpdateWorkloadEnvironmentVariableInput `json:"environmentVariables,omitempty"`
 	Replicas             *UpdateApplicationReplicasInput                    `json:"replicas,omitempty"`
+	Image                *string                                            `json:"image,omitempty"`
 }
 
 type UpdateApplicationReplicasInput struct {

--- a/internal/workload/application/queries.go
+++ b/internal/workload/application/queries.go
@@ -172,6 +172,7 @@ func Update(ctx context.Context, input UpdateApplicationInput) (*UpdateApplicati
 	}
 
 	var changedFields []*activitylog.ResourceChangedField
+	var updateImageResource *string
 
 	if len(input.EnvironmentVariables) > 0 {
 		merged := workload.MergeEnvVars(app.Spec.Env, input.EnvironmentVariables)
@@ -213,6 +214,26 @@ func Update(ctx context.Context, input UpdateApplicationInput) (*UpdateApplicati
 		}
 	}
 
+	if input.Image != nil {
+		effectiveImage := app.Status.EffectiveImage
+		newImage := *input.Image
+		if newImage != effectiveImage {
+			if effectiveImage != "" {
+				changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.image", OldValue: &effectiveImage, NewValue: &newImage})
+			} else {
+				changedFields = append(changedFields, &activitylog.ResourceChangedField{Field: "spec.image", NewValue: &newImage})
+			}
+
+			if app.Spec.Image != "" {
+				// Image is set directly in the Application spec
+				app.Spec.Image = newImage
+			} else {
+				// Image is managed by a separate Image resource (WorkloadImage pattern)
+				updateImageResource = &newImage
+			}
+		}
+	}
+
 	if len(changedFields) == 0 {
 		return &UpdateApplicationPayload{
 			TeamSlug:        input.TeamSlug,
@@ -233,6 +254,30 @@ func Update(ctx context.Context, input UpdateApplicationInput) (*UpdateApplicati
 
 	if _, err := client.Namespace(input.TeamSlug.String()).Update(ctx, &unstructured.Unstructured{Object: obj}, metav1.UpdateOptions{}); err != nil {
 		return nil, fmt.Errorf("updating application: %w", err)
+	}
+
+	if updateImageResource != nil {
+		imageClient, err := w.ImpersonatedClient(ctx, input.EnvironmentName, watcher.WithImpersonatedClientGVR(schema.GroupVersionResource{
+			Group:    "nais.io",
+			Version:  "v1",
+			Resource: "images",
+		}))
+		if err != nil {
+			return nil, fmt.Errorf("creating image resource client: %w", err)
+		}
+
+		imageObj, err := imageClient.Namespace(input.TeamSlug.String()).Get(ctx, input.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("getting image resource: %w", err)
+		}
+
+		if err := unstructured.SetNestedField(imageObj.Object, *updateImageResource, "spec", "image"); err != nil {
+			return nil, fmt.Errorf("setting image field: %w", err)
+		}
+
+		if _, err := imageClient.Namespace(input.TeamSlug.String()).Update(ctx, imageObj, metav1.UpdateOptions{}); err != nil {
+			return nil, fmt.Errorf("updating image resource: %w", err)
+		}
 	}
 
 	if err := activitylog.Create(ctx, activitylog.CreateInput{

--- a/internal/workload/application/queries.go
+++ b/internal/workload/application/queries.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/nais/api/internal/activitylog"
 	"github.com/nais/api/internal/auth/authz"
+	"github.com/nais/api/internal/graph/apierror"
 	"github.com/nais/api/internal/graph/ident"
 	"github.com/nais/api/internal/graph/model"
 	"github.com/nais/api/internal/graph/pagination"
@@ -16,6 +17,7 @@ import (
 	"github.com/nais/api/internal/slug"
 	"github.com/nais/api/internal/workload"
 	nais_io_v1 "github.com/nais/liberator/pkg/apis/nais.io/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -268,6 +270,12 @@ func Update(ctx context.Context, input UpdateApplicationInput) (*UpdateApplicati
 
 		imageObj, err := imageClient.Namespace(input.TeamSlug.String()).Get(ctx, input.Name, metav1.GetOptions{})
 		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil, apierror.Errorf("Image resource %q not found in %s. The application may not be using the image resource pattern.", input.Name, input.EnvironmentName)
+			}
+			if k8serrors.IsForbidden(err) {
+				return nil, apierror.Errorf("You do not have permission to read the image resource for %q.", input.Name)
+			}
 			return nil, fmt.Errorf("getting image resource: %w", err)
 		}
 
@@ -276,6 +284,12 @@ func Update(ctx context.Context, input UpdateApplicationInput) (*UpdateApplicati
 		}
 
 		if _, err := imageClient.Namespace(input.TeamSlug.String()).Update(ctx, imageObj, metav1.UpdateOptions{}); err != nil {
+			if k8serrors.IsForbidden(err) {
+				return nil, apierror.Errorf("You do not have permission to update the image resource for %q.", input.Name)
+			}
+			if k8serrors.IsConflict(err) {
+				return nil, apierror.Errorf("The image resource for %q was modified by another process. Please try again.", input.Name)
+			}
 			return nil, fmt.Errorf("updating image resource: %w", err)
 		}
 	}

--- a/internal/workload/instancegroup/models.go
+++ b/internal/workload/instancegroup/models.go
@@ -16,6 +16,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+type ApplicationHistory struct {
+	Image      string    `json:"image"`
+	DeployedAt time.Time `json:"deployedAt"`
+}
+
 // InstanceGroup represents a group of identical instances (backed by a ReplicaSet).
 // All instances in the group share the same configuration (env vars, mounts, image).
 type InstanceGroup struct {

--- a/internal/workload/instancegroup/queries.go
+++ b/internal/workload/instancegroup/queries.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nais/api/internal/workload/application"
 	"github.com/nais/api/internal/workload/secret"
 	nais_io_v1alpha1 "github.com/nais/liberator/pkg/apis/nais.io/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -51,6 +52,51 @@ func ListForApplication(ctx context.Context, teamSlug slug.Slug, environmentName
 	slices.SortFunc(ret, func(a, b *InstanceGroup) int {
 		return b.Created.Compare(a.Created)
 	})
+
+	return ret, nil
+}
+
+func ImageHistory(ctx context.Context, teamSlug slug.Slug, environmentName, appName string) ([]*ApplicationHistory, error) {
+	l := fromContext(ctx)
+
+	nameReq, err := labels.NewRequirement("app", selection.Equals, []string{appName})
+	if err != nil {
+		return nil, err
+	}
+	selector := labels.NewSelector().Add(*nameReq)
+
+	replicaSets := watcher.Objects(l.rsWatcher.GetByNamespace(
+		teamSlug.String(),
+		watcher.WithLabels(selector),
+		watcher.InCluster(environmentName),
+	))
+	slices.SortFunc(replicaSets, func(a, b *appsv1.ReplicaSet) int {
+		return b.CreationTimestamp.Compare(a.CreationTimestamp.Time)
+	})
+
+	seen := make(map[string]struct{})
+	ret := make([]*ApplicationHistory, 0, len(replicaSets))
+
+	for _, rs := range replicaSets {
+		image := ""
+		for _, c := range rs.Spec.Template.Spec.Containers {
+			if c.Name == appName {
+				image = c.Image
+				break
+			}
+		}
+		if image == "" {
+			continue
+		}
+		if _, ok := seen[image]; ok {
+			continue
+		}
+		seen[image] = struct{}{}
+		ret = append(ret, &ApplicationHistory{
+			Image:      image,
+			DeployedAt: rs.CreationTimestamp.Time,
+		})
+	}
 
 	return ret, nil
 }


### PR DESCRIPTION
Extends the existing updateApplication mutation with an optional image field, allowing users to set a full container image reference on the NAIS Application CR. This follows the same pattern as environmentVariables and replicas, including activity log entries with old/new values.