### PR TITLE
feat(environment): expose oidcIssuerURL

### DIFF
--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -125,7 +125,7 @@ func run(ctx context.Context, cfg *Config, log logrus.FieldLogger) error {
 
 	environmentmapper.SetMapping(cfg.ReplaceEnvironmentNames)
 
-	if err := syncEnvironments(ctx, pool, cfg.K8s.ClusterList()); err != nil {
+	if err := syncEnvironments(ctx, pool, cfg.K8s.ClusterList(), cfg.K8s.OIDCIssuers); err != nil {
 		return err
 	}
 

--- a/internal/cmd/api/environments.go
+++ b/internal/cmd/api/environments.go
@@ -4,21 +4,32 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/nais/api/internal/auth/middleware"
 	"github.com/nais/api/internal/database"
 	"github.com/nais/api/internal/environment"
 	"github.com/nais/api/internal/environmentmapper"
 )
 
-func syncEnvironments(ctx context.Context, pool *pgxpool.Pool, clusters ClusterList) error {
+func syncEnvironments(ctx context.Context, pool *pgxpool.Pool, clusters ClusterList, oidcIssuers middleware.KubernetesIssuers) error {
 	ctx = database.NewLoaderContext(ctx, pool)
 	ctx = environment.NewLoaderContext(ctx, pool)
 
-	syncEnvs := make([]*environment.Environment, 0)
+	issuerByEnv := make(map[string]string, len(oidcIssuers))
+	for _, iss := range oidcIssuers {
+		issuerByEnv[iss.Environment] = iss.Issuer
+	}
+
+	syncEnvs := make([]*environment.Environment, 0, len(clusters))
 	for name, env := range clusters {
-		syncEnvs = append(syncEnvs, &environment.Environment{
-			Name: environmentmapper.EnvironmentName(name),
+		envName := environmentmapper.EnvironmentName(name)
+		e := &environment.Environment{
+			Name: envName,
 			GCP:  env.GCP,
-		})
+		}
+		if issuer, ok := issuerByEnv[envName]; ok {
+			e.OIDCIssuerURL = &issuer
+		}
+		syncEnvs = append(syncEnvs, e)
 	}
 
 	return environment.SyncEnvironments(ctx, syncEnvs)

--- a/internal/database/migrations/0069_environment_oidc_issuer_url.sql
+++ b/internal/database/migrations/0069_environment_oidc_issuer_url.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+ALTER TABLE environments
+ADD COLUMN oidc_issuer_url TEXT
+;

--- a/internal/environment/environmentsql/environment.sql.go
+++ b/internal/environment/environmentsql/environment.sql.go
@@ -18,7 +18,7 @@ func (q *Queries) DeleteAllEnvironments(ctx context.Context) error {
 
 const get = `-- name: Get :one
 SELECT
-	name, gcp
+	name, gcp, oidc_issuer_url
 FROM
 	environments
 WHERE
@@ -28,30 +28,31 @@ WHERE
 func (q *Queries) Get(ctx context.Context, name string) (*Environment, error) {
 	row := q.db.QueryRow(ctx, get, name)
 	var i Environment
-	err := row.Scan(&i.Name, &i.Gcp)
+	err := row.Scan(&i.Name, &i.Gcp, &i.OidcIssuerUrl)
 	return &i, err
 }
 
 const insertEnvironment = `-- name: InsertEnvironment :exec
 INSERT INTO
-	environments (name, gcp)
+	environments (name, gcp, oidc_issuer_url)
 VALUES
-	($1, $2)
+	($1, $2, $3)
 `
 
 type InsertEnvironmentParams struct {
-	Name string
-	Gcp  bool
+	Name          string
+	Gcp           bool
+	OidcIssuerUrl *string
 }
 
 func (q *Queries) InsertEnvironment(ctx context.Context, arg InsertEnvironmentParams) error {
-	_, err := q.db.Exec(ctx, insertEnvironment, arg.Name, arg.Gcp)
+	_, err := q.db.Exec(ctx, insertEnvironment, arg.Name, arg.Gcp, arg.OidcIssuerUrl)
 	return err
 }
 
 const list = `-- name: List :many
 SELECT
-	name, gcp
+	name, gcp, oidc_issuer_url
 FROM
 	environments
 ORDER BY
@@ -67,7 +68,7 @@ func (q *Queries) List(ctx context.Context) ([]*Environment, error) {
 	items := []*Environment{}
 	for rows.Next() {
 		var i Environment
-		if err := rows.Scan(&i.Name, &i.Gcp); err != nil {
+		if err := rows.Scan(&i.Name, &i.Gcp, &i.OidcIssuerUrl); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)
@@ -80,7 +81,7 @@ func (q *Queries) List(ctx context.Context) ([]*Environment, error) {
 
 const listByNames = `-- name: ListByNames :many
 SELECT
-	name, gcp
+	name, gcp, oidc_issuer_url
 FROM
 	environments
 WHERE
@@ -98,7 +99,7 @@ func (q *Queries) ListByNames(ctx context.Context, names []string) ([]*Environme
 	items := []*Environment{}
 	for rows.Next() {
 		var i Environment
-		if err := rows.Scan(&i.Name, &i.Gcp); err != nil {
+		if err := rows.Scan(&i.Name, &i.Gcp, &i.OidcIssuerUrl); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/internal/environment/environmentsql/models.go
+++ b/internal/environment/environmentsql/models.go
@@ -4,6 +4,7 @@ package environmentsql
 
 // This table is used to store the environments that are available in the system. It will be emptied and repopulated when the system starts.
 type Environment struct {
-	Name string
-	Gcp  bool
+	Name          string
+	Gcp           bool
+	OidcIssuerUrl *string
 }

--- a/internal/environment/model.go
+++ b/internal/environment/model.go
@@ -17,8 +17,9 @@ type (
 )
 
 type Environment struct {
-	Name string `json:"name"`
-	GCP  bool   `json:"-"`
+	Name          string  `json:"name"`
+	GCP           bool    `json:"-"`
+	OIDCIssuerURL *string `json:"oidcIssuerURL,omitempty"`
 }
 
 func (Environment) IsNode() {}
@@ -61,6 +62,7 @@ func (e EnvironmentOrderField) MarshalGQL(w io.Writer) {
 
 func toGraphEnvironment(e *environmentsql.Environment) *Environment {
 	return &Environment{
-		Name: e.Name,
+		Name:          e.Name,
+		OIDCIssuerURL: e.OidcIssuerUrl,
 	}
 }

--- a/internal/environment/queries.go
+++ b/internal/environment/queries.go
@@ -60,7 +60,7 @@ func SyncEnvironments(ctx context.Context, envs []*Environment) error {
 		}
 
 		for _, env := range envs {
-			if err := insertEnvironment(ctx, env.Name, env.GCP); err != nil {
+			if err := insertEnvironment(ctx, env); err != nil {
 				return err
 			}
 		}
@@ -73,9 +73,10 @@ func deleteAllEnvironments(ctx context.Context) error {
 	return db(ctx).DeleteAllEnvironments(ctx)
 }
 
-func insertEnvironment(ctx context.Context, name string, gcp bool) error {
+func insertEnvironment(ctx context.Context, env *Environment) error {
 	return db(ctx).InsertEnvironment(ctx, environmentsql.InsertEnvironmentParams{
-		Name: name,
-		Gcp:  gcp,
+		Name:          env.Name,
+		Gcp:           env.GCP,
+		OidcIssuerUrl: env.OIDCIssuerURL,
 	})
 }

--- a/internal/environment/queries/environment.sql
+++ b/internal/environment/queries/environment.sql
@@ -33,7 +33,7 @@ DELETE FROM environments
 
 -- name: InsertEnvironment :exec
 INSERT INTO
-	environments (name, gcp)
+	environments (name, gcp, oidc_issuer_url)
 VALUES
-	(@name, @gcp)
+	(@name, @gcp, @oidc_issuer_url)
 ;

--- a/internal/graph/gengql/environments.generated.go
+++ b/internal/graph/gengql/environments.generated.go
@@ -143,6 +143,29 @@ func (ec *executionContext) fieldContext_Environment_name(_ context.Context, fie
 	return graphql.NewScalarFieldContext("Environment", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
+func (ec *executionContext) _Environment_oidcIssuerURL(ctx context.Context, field graphql.CollectedField, obj *environment.Environment) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Environment_oidcIssuerURL(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.OIDCIssuerURL, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Environment_oidcIssuerURL(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Environment", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
 func (ec *executionContext) _Environment_metrics(ctx context.Context, field graphql.CollectedField, obj *environment.Environment) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -452,6 +475,8 @@ func (ec *executionContext) _Environment(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "oidcIssuerURL":
+			out.Values[i] = ec._Environment_oidcIssuerURL(ctx, field, obj)
 		case "metrics":
 			field := field
 

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -909,10 +909,11 @@ type ComplexityRoot struct {
 	}
 
 	Environment struct {
-		ID        func(childComplexity int) int
-		Metrics   func(childComplexity int, input metrics.MetricsQueryInput) int
-		Name      func(childComplexity int) int
-		Workloads func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, orderBy *workload.EnvironmentWorkloadOrder) int
+		ID            func(childComplexity int) int
+		Metrics       func(childComplexity int, input metrics.MetricsQueryInput) int
+		Name          func(childComplexity int) int
+		OIDCIssuerURL func(childComplexity int) int
+		Workloads     func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, orderBy *workload.EnvironmentWorkloadOrder) int
 	}
 
 	EnvironmentConnection struct {
@@ -6564,6 +6565,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Environment.Name(childComplexity), true
+
+	case "Environment.oidcIssuerURL":
+		if e.ComplexityRoot.Environment.OIDCIssuerURL == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Environment.OIDCIssuerURL(childComplexity), true
 
 	case "Environment.workloads":
 		if e.ComplexityRoot.Environment.Workloads == nil {
@@ -22310,6 +22318,11 @@ type Environment implements Node {
 	Unique name of the environment.
 	"""
 	name: String!
+
+	"""
+	The OIDC issuer URL for workload identity tokens in the environment. Null for environments that do not support workload identity.
+	"""
+	oidcIssuerURL: String
 }
 
 extend type TeamEnvironment {
@@ -32970,6 +32983,8 @@ func (ec *executionContext) childFields_Environment(ctx context.Context, field g
 		return ec.fieldContext_Environment_id(ctx, field)
 	case "name":
 		return ec.fieldContext_Environment_name(ctx, field)
+	case "oidcIssuerURL":
+		return ec.fieldContext_Environment_oidcIssuerURL(ctx, field)
 	case "metrics":
 		return ec.fieldContext_Environment_metrics(ctx, field)
 	case "workloads":

--- a/internal/graph/schema/environments.graphqls
+++ b/internal/graph/schema/environments.graphqls
@@ -95,6 +95,11 @@ type Environment implements Node {
 	Unique name of the environment.
 	"""
 	name: String!
+
+	"""
+	The OIDC issuer URL for workload identity tokens in the environment. Null for environments that do not support workload identity.
+	"""
+	oidcIssuerURL: String
 }
 
 extend type TeamEnvironment {


### PR DESCRIPTION
This allows end-users to resolve the OIDC metadata document to configure workload identity federation in third-party systems.