### PR TITLE
fix(serviceaccount): aggregate lastUsedAt across tokens and bindings

### DIFF
--- a/integration_tests/serviceaccount_tokens_full.lua
+++ b/integration_tests/serviceaccount_tokens_full.lua
@@ -404,6 +404,27 @@ end)
 -- Test: Token is usable for authentication (Bearer header)
 local bearerHeader = string.format("Bearer %s", State.tokenSecret1)
 
+-- Before the token is used, the service account aggregate lastUsedAt must be null.
+Test.gql("Service account lastUsedAt is null before any token use", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query(string.format([[
+		query {
+			serviceAccount(id: "%s") {
+				lastUsedAt
+			}
+		}
+	]], State.saID))
+
+	t.check {
+		data = {
+			serviceAccount = {
+				lastUsedAt = Null,
+			},
+		},
+	}
+end)
+
 Test.gql("Authenticate as service account using token", function(t)
 	t.addHeader("authorization", bearerHeader)
 
@@ -421,6 +442,27 @@ Test.gql("Authenticate as service account using token", function(t)
 		data = {
 			me = {
 				name = "token-test-sa",
+			},
+		},
+	}
+end)
+
+-- After authenticating with a token, the service account aggregate lastUsedAt reflects that usage.
+Test.gql("Service account lastUsedAt reflects token usage", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query(string.format([[
+		query {
+			serviceAccount(id: "%s") {
+				lastUsedAt
+			}
+		}
+	]], State.saID))
+
+	t.check {
+		data = {
+			serviceAccount = {
+				lastUsedAt = NotNull(),
 			},
 		},
 	}

--- a/internal/serviceaccount/dataloader.go
+++ b/internal/serviceaccount/dataloader.go
@@ -2,6 +2,7 @@ package serviceaccount
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -28,6 +29,7 @@ type loaders struct {
 	serviceAccountLoader        *dataloadgen.Loader[uuid.UUID, *ServiceAccount]
 	serviceAccountTokenLoader   *dataloadgen.Loader[uuid.UUID, *ServiceAccountToken]
 	serviceAccountBindingLoader *dataloadgen.Loader[uuid.UUID, *ServiceAccountWorkloadBinding]
+	lastUsedAtLoader            *dataloadgen.Loader[uuid.UUID, *time.Time]
 }
 
 func newLoaders(dbConn *pgxpool.Pool) *loaders {
@@ -39,6 +41,7 @@ func newLoaders(dbConn *pgxpool.Pool) *loaders {
 		serviceAccountLoader:        dataloadgen.NewLoader(serviceAccountLoader.list, loader.DefaultDataLoaderOptions...),
 		serviceAccountTokenLoader:   dataloadgen.NewLoader(serviceAccountLoader.listTokens, loader.DefaultDataLoaderOptions...),
 		serviceAccountBindingLoader: dataloadgen.NewLoader(serviceAccountLoader.listBindings, loader.DefaultDataLoaderOptions...),
+		lastUsedAtLoader:            dataloadgen.NewLoader(serviceAccountLoader.lastUsedAt, loader.DefaultDataLoaderOptions...),
 	}
 }
 
@@ -59,6 +62,36 @@ func (l dataloader) listTokens(ctx context.Context, serviceAccountTokenIDs []uui
 func (l dataloader) listBindings(ctx context.Context, ids []uuid.UUID) ([]*ServiceAccountWorkloadBinding, []error) {
 	makeKey := func(obj *ServiceAccountWorkloadBinding) uuid.UUID { return obj.UUID }
 	return loader.LoadModels(ctx, ids, l.db.GetBindingsByIDs, toGraphServiceAccountWorkloadBinding, makeKey)
+}
+
+// lastUsedAt batches the aggregate last-used timestamp per service account. The value is the most recent usage
+// across all of the account's tokens and workload bindings. Accounts that have never been used resolve to nil
+// (not an error).
+func (l dataloader) lastUsedAt(ctx context.Context, ids []uuid.UUID) ([]*time.Time, []error) {
+	rows, err := l.db.LastUsedAtForServiceAccounts(ctx, ids)
+	if err != nil {
+		errs := make([]error, len(ids))
+		for i := range errs {
+			errs[i] = err
+		}
+		return make([]*time.Time, len(ids)), errs
+	}
+
+	byID := make(map[uuid.UUID]time.Time, len(rows))
+	for _, row := range rows {
+		if row.LastUsedAt.Valid {
+			byID[row.ServiceAccountID] = row.LastUsedAt.Time
+		}
+	}
+
+	ret := make([]*time.Time, len(ids))
+	for i, id := range ids {
+		if ts, ok := byID[id]; ok {
+			t := ts
+			ret[i] = &t
+		}
+	}
+	return ret, make([]error, len(ids))
 }
 
 func db(ctx context.Context) *serviceaccountsql.Queries {

--- a/internal/serviceaccount/queries.go
+++ b/internal/serviceaccount/queries.go
@@ -548,14 +548,5 @@ func RevokeRole(ctx context.Context, input RevokeRoleFromServiceAccountInput) (*
 }
 
 func LastUsedAt(ctx context.Context, id uuid.UUID) (*time.Time, error) {
-	ts, err := db(ctx).LastUsedAt(ctx, id)
-	if err != nil {
-		return nil, err
-	}
-
-	if !ts.Valid {
-		return nil, nil
-	}
-
-	return &ts.Time, nil
+	return fromContext(ctx).lastUsedAtLoader.Load(ctx, id)
 }

--- a/internal/serviceaccount/queries/service_accounts.sql
+++ b/internal/serviceaccount/queries/service_accounts.sql
@@ -170,13 +170,30 @@ WHERE
 	id = @id
 ;
 
--- name: LastUsedAt :one
+-- name: LastUsedAtForServiceAccounts :many
 SELECT
+	service_account_id,
 	MAX(last_used_at)::TIMESTAMPTZ AS last_used_at
 FROM
-	service_account_tokens
+	(
+		SELECT
+			service_account_id,
+			last_used_at
+		FROM
+			service_account_tokens
+		UNION ALL
+		SELECT
+			service_account_id,
+			last_used_at
+		FROM
+			service_account_workload_bindings
+	) AS usage
 WHERE
-	service_account_id = @service_account_id
+	service_account_id = ANY (@ids::UUID[])
+GROUP BY
+	service_account_id
+ORDER BY
+	service_account_id
 ;
 
 -- TODO: Remove once static service accounts has been removed

--- a/internal/serviceaccount/serviceaccountsql/querier.go
+++ b/internal/serviceaccount/serviceaccountsql/querier.go
@@ -6,7 +6,6 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type Querier interface {
@@ -25,7 +24,7 @@ type Querier interface {
 	GetByName(ctx context.Context, name string) (*ServiceAccount, error)
 	GetServiceAccountAndTokenBySecret(ctx context.Context, token string) (*GetServiceAccountAndTokenBySecretRow, error)
 	GetTokensByIDs(ctx context.Context, ids []uuid.UUID) ([]*ServiceAccountToken, error)
-	LastUsedAt(ctx context.Context, serviceAccountID uuid.UUID) (pgtype.Timestamptz, error)
+	LastUsedAtForServiceAccounts(ctx context.Context, ids []uuid.UUID) ([]*LastUsedAtForServiceAccountsRow, error)
 	List(ctx context.Context, arg ListParams) ([]*ListRow, error)
 	ListBindingsForServiceAccount(ctx context.Context, arg ListBindingsForServiceAccountParams) ([]*ListBindingsForServiceAccountRow, error)
 	ListForTeam(ctx context.Context, arg ListForTeamParams) ([]*ListForTeamRow, error)

--- a/internal/serviceaccount/serviceaccountsql/service_accounts.sql.go
+++ b/internal/serviceaccount/serviceaccountsql/service_accounts.sql.go
@@ -271,20 +271,55 @@ func (q *Queries) GetTokensByIDs(ctx context.Context, ids []uuid.UUID) ([]*Servi
 	return items, nil
 }
 
-const lastUsedAt = `-- name: LastUsedAt :one
+const lastUsedAtForServiceAccounts = `-- name: LastUsedAtForServiceAccounts :many
 SELECT
+	service_account_id,
 	MAX(last_used_at)::TIMESTAMPTZ AS last_used_at
 FROM
-	service_account_tokens
+	(
+		SELECT
+			service_account_id,
+			last_used_at
+		FROM
+			service_account_tokens
+		UNION ALL
+		SELECT
+			service_account_id,
+			last_used_at
+		FROM
+			service_account_workload_bindings
+	) AS usage
 WHERE
-	service_account_id = $1
+	service_account_id = ANY ($1::UUID[])
+GROUP BY
+	service_account_id
+ORDER BY
+	service_account_id
 `
 
-func (q *Queries) LastUsedAt(ctx context.Context, serviceAccountID uuid.UUID) (pgtype.Timestamptz, error) {
-	row := q.db.QueryRow(ctx, lastUsedAt, serviceAccountID)
-	var last_used_at pgtype.Timestamptz
-	err := row.Scan(&last_used_at)
-	return last_used_at, err
+type LastUsedAtForServiceAccountsRow struct {
+	ServiceAccountID uuid.UUID
+	LastUsedAt       pgtype.Timestamptz
+}
+
+func (q *Queries) LastUsedAtForServiceAccounts(ctx context.Context, ids []uuid.UUID) ([]*LastUsedAtForServiceAccountsRow, error) {
+	rows, err := q.db.Query(ctx, lastUsedAtForServiceAccounts, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*LastUsedAtForServiceAccountsRow{}
+	for rows.Next() {
+		var i LastUsedAtForServiceAccountsRow
+		if err := rows.Scan(&i.ServiceAccountID, &i.LastUsedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const list = `-- name: List :many


### PR DESCRIPTION
ServiceAccount.lastUsedAt only aggregated MAX(last_used_at) over tokens, ignoring workload bindings, so accounts authenticating via workload bindings always reported null. The per-row resolver also caused N+1 in the paginated list.

Aggregate at read time over both tokens and bindings via a batched dataloader query.