### PR TITLE
Return newly created run instead of the request body

### DIFF
--- a/.github/actions/go-cache/action.yaml
+++ b/.github/actions/go-cache/action.yaml
@@ -49,7 +49,7 @@ runs:
         echo "result=${ESCAPED_RESULT_OUTPUT}" >> "$GITHUB_OUTPUT"
 
     - name: Cache go modules
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ steps.go-cache.outputs.gocache }}

--- a/internal/workload/job/queries.go
+++ b/internal/workload/job/queries.go
@@ -247,7 +247,8 @@ func Trigger(ctx context.Context, teamSlug slug.Slug, environmentName, name, run
 		return nil, fmt.Errorf("creating job client: %w", err)
 	}
 
-	if _, err = jobClient.Namespace(teamSlug.String()).Create(ctx, jobRun, metav1.CreateOptions{}); err != nil {
+	newRun, err := jobClient.Namespace(teamSlug.String()).Create(ctx, jobRun, metav1.CreateOptions{})
+	if err != nil {
 		return nil, err
 	}
 
@@ -263,7 +264,7 @@ func Trigger(ctx context.Context, teamSlug slug.Slug, environmentName, name, run
 	}
 
 	jobRunBatch := &batchv1.Job{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(jobRun.Object, jobRunBatch); err != nil {
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(newRun.Object, jobRunBatch); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The ID was not returned correctly from the Graph because of missing teamSlug/Namespace on the job request body.
Now we return the created object returned by the .Create instead, which should contain all the data required.