### PR TITLE
Remove deprecated fields

### DIFF
--- a/integration_tests/workload_configs.lua
+++ b/integration_tests/workload_configs.lua
@@ -141,8 +141,10 @@ Test.gql("Configs with workloads", function(t)
 						workloads {
 							nodes {
 								name
-								environment {
-									name
+								teamEnvironment {
+									environment {
+										name
+									}
 								}
 							}
 						}
@@ -164,8 +166,10 @@ Test.gql("Configs with workloads", function(t)
 								nodes = {
 									{
 										name = "app-with-configs-via-envfrom",
-										environment = {
-											name = "dev",
+										teamEnvironment = {
+											environment = {
+												name = "dev",
+											},
 										},
 									},
 								},
@@ -183,8 +187,10 @@ Test.gql("Configs with workloads", function(t)
 								nodes = {
 									{
 										name = "app-with-configs-via-filesfrom",
-										environment = {
-											name = "staging",
+										teamEnvironment = {
+											environment = {
+												name = "staging",
+											},
 										},
 									},
 								},

--- a/integration_tests/workload_secrets.lua
+++ b/integration_tests/workload_secrets.lua
@@ -141,8 +141,10 @@ Test.gql("Secrets with workloads", function(t)
 						workloads {
 							nodes {
 								name
-								environment {
-									name
+								teamEnvironment {
+									environment {
+										name
+									}
 								}
 							}
 						}
@@ -164,8 +166,10 @@ Test.gql("Secrets with workloads", function(t)
 								nodes = {
 									{
 										name = "app-with-secrets-via-envfrom",
-										environment = {
-											name = "dev",
+										teamEnvironment = {
+											environment = {
+												name = "dev",
+											},
 										},
 									},
 								},
@@ -183,8 +187,10 @@ Test.gql("Secrets with workloads", function(t)
 								nodes = {
 									{
 										name = "app-with-secrets-via-filesfrom",
-										environment = {
-											name = "staging",
+										teamEnvironment = {
+											environment = {
+												name = "staging",
+											},
 										},
 									},
 								},

--- a/internal/graph/applications.resolvers.go
+++ b/internal/graph/applications.resolvers.go
@@ -25,10 +25,6 @@ func (r *applicationResolver) Team(ctx context.Context, obj *application.Applica
 	return team, err
 }
 
-func (r *applicationResolver) Environment(ctx context.Context, obj *application.Application) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *applicationResolver) TeamEnvironment(ctx context.Context, obj *application.Application) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }

--- a/internal/graph/bigquery.resolvers.go
+++ b/internal/graph/bigquery.resolvers.go
@@ -27,10 +27,6 @@ func (r *bigQueryDatasetResolver) Team(ctx context.Context, obj *bigquery.BigQue
 	return team.Get(ctx, obj.TeamSlug)
 }
 
-func (r *bigQueryDatasetResolver) Environment(ctx context.Context, obj *bigquery.BigQueryDataset) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *bigQueryDatasetResolver) TeamEnvironment(ctx context.Context, obj *bigquery.BigQueryDataset) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }

--- a/internal/graph/bucket.resolvers.go
+++ b/internal/graph/bucket.resolvers.go
@@ -24,10 +24,6 @@ func (r *bucketResolver) Team(ctx context.Context, obj *bucket.Bucket) (*team.Te
 	return team.Get(ctx, obj.TeamSlug)
 }
 
-func (r *bucketResolver) Environment(ctx context.Context, obj *bucket.Bucket) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *bucketResolver) TeamEnvironment(ctx context.Context, obj *bucket.Bucket) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }

--- a/internal/graph/gengql/applications.generated.go
+++ b/internal/graph/gengql/applications.generated.go
@@ -46,7 +46,6 @@ import (
 
 type ApplicationResolver interface {
 	Team(ctx context.Context, obj *application.Application) (*team.Team, error)
-	Environment(ctx context.Context, obj *application.Application) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *application.Application) (*team.TeamEnvironment, error)
 
 	AuthIntegrations(ctx context.Context, obj *application.Application) ([]workload.ApplicationAuthIntegrations, error)
@@ -579,38 +578,6 @@ func (ec *executionContext) fieldContext_Application_team(_ context.Context, fie
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Team(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Application_environment(ctx context.Context, field graphql.CollectedField, obj *application.Application) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Application_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.Application().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_Application_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Application",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
 		},
 	}
 	return fc, nil
@@ -4873,42 +4840,6 @@ func (ec *executionContext) _Application(ctx context.Context, sel ast.SelectionS
 					}
 				}()
 				res = ec._Application_team(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Application_environment(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/bigquery.generated.go
+++ b/internal/graph/gengql/bigquery.generated.go
@@ -25,7 +25,6 @@ import (
 
 type BigQueryDatasetResolver interface {
 	Team(ctx context.Context, obj *bigquery.BigQueryDataset) (*team.Team, error)
-	Environment(ctx context.Context, obj *bigquery.BigQueryDataset) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *bigquery.BigQueryDataset) (*team.TeamEnvironment, error)
 
 	Access(ctx context.Context, obj *bigquery.BigQueryDataset, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, orderBy *bigquery.BigQueryDatasetAccessOrder) (*pagination.Connection[*bigquery.BigQueryDatasetAccess], error)
@@ -169,38 +168,6 @@ func (ec *executionContext) fieldContext_BigQueryDataset_team(_ context.Context,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Team(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _BigQueryDataset_environment(ctx context.Context, field graphql.CollectedField, obj *bigquery.BigQueryDataset) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_BigQueryDataset_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.BigQueryDataset().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_BigQueryDataset_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "BigQueryDataset",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
 		},
 	}
 	return fc, nil
@@ -1130,42 +1097,6 @@ func (ec *executionContext) _BigQueryDataset(ctx context.Context, sel ast.Select
 					}
 				}()
 				res = ec._BigQueryDataset_team(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._BigQueryDataset_environment(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/bucket.generated.go
+++ b/internal/graph/gengql/bucket.generated.go
@@ -23,7 +23,6 @@ import (
 
 type BucketResolver interface {
 	Team(ctx context.Context, obj *bucket.Bucket) (*team.Team, error)
-	Environment(ctx context.Context, obj *bucket.Bucket) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *bucket.Bucket) (*team.TeamEnvironment, error)
 
 	Workload(ctx context.Context, obj *bucket.Bucket) (workload.Workload, error)
@@ -117,38 +116,6 @@ func (ec *executionContext) fieldContext_Bucket_team(_ context.Context, field gr
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Team(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Bucket_environment(ctx context.Context, field graphql.CollectedField, obj *bucket.Bucket) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Bucket_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.Bucket().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_Bucket_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Bucket",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
 		},
 	}
 	return fc, nil
@@ -713,42 +680,6 @@ func (ec *executionContext) _Bucket(ctx context.Context, sel ast.SelectionSet, o
 					}
 				}()
 				res = ec._Bucket_team(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Bucket_environment(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/jobs.generated.go
+++ b/internal/graph/gengql/jobs.generated.go
@@ -50,7 +50,6 @@ type DeleteJobRunPayloadResolver interface {
 }
 type JobResolver interface {
 	Team(ctx context.Context, obj *job.Job) (*team.Team, error)
-	Environment(ctx context.Context, obj *job.Job) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *job.Job) (*team.TeamEnvironment, error)
 
 	AuthIntegrations(ctx context.Context, obj *job.Job) ([]workload.JobAuthIntegrations, error)
@@ -689,38 +688,6 @@ func (ec *executionContext) fieldContext_Job_team(_ context.Context, field graph
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Team(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Job_environment(ctx context.Context, field graphql.CollectedField, obj *job.Job) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Job_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.Job().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_Job_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Job",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
 		},
 	}
 	return fc, nil
@@ -4742,42 +4709,6 @@ func (ec *executionContext) _Job(ctx context.Context, sel ast.SelectionSet, obj 
 					}
 				}()
 				res = ec._Job_team(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Job_environment(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/kafka.generated.go
+++ b/internal/graph/gengql/kafka.generated.go
@@ -23,7 +23,6 @@ import (
 
 type KafkaTopicResolver interface {
 	Team(ctx context.Context, obj *kafkatopic.KafkaTopic) (*team.Team, error)
-	Environment(ctx context.Context, obj *kafkatopic.KafkaTopic) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *kafkatopic.KafkaTopic) (*team.TeamEnvironment, error)
 	ACL(ctx context.Context, obj *kafkatopic.KafkaTopic, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *kafkatopic.KafkaTopicACLFilter, orderBy *kafkatopic.KafkaTopicACLOrder) (*pagination.Connection[*kafkatopic.KafkaTopicACL], error)
 }
@@ -345,38 +344,6 @@ func (ec *executionContext) fieldContext_KafkaTopic_team(_ context.Context, fiel
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Team(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _KafkaTopic_environment(ctx context.Context, field graphql.CollectedField, obj *kafkatopic.KafkaTopic) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_KafkaTopic_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.KafkaTopic().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_KafkaTopic_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "KafkaTopic",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
 		},
 	}
 	return fc, nil
@@ -1706,42 +1673,6 @@ func (ec *executionContext) _KafkaTopic(ctx context.Context, sel ast.SelectionSe
 					}
 				}()
 				res = ec._KafkaTopic_team(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._KafkaTopic_environment(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/opensearch.generated.go
+++ b/internal/graph/gengql/opensearch.generated.go
@@ -29,7 +29,6 @@ import (
 
 type OpenSearchResolver interface {
 	Team(ctx context.Context, obj *opensearch.OpenSearch) (*team.Team, error)
-	Environment(ctx context.Context, obj *opensearch.OpenSearch) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *opensearch.OpenSearch) (*team.TeamEnvironment, error)
 
 	State(ctx context.Context, obj *opensearch.OpenSearch) (opensearch.OpenSearchState, error)
@@ -367,38 +366,6 @@ func (ec *executionContext) fieldContext_OpenSearch_team(_ context.Context, fiel
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Team(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _OpenSearch_environment(ctx context.Context, field graphql.CollectedField, obj *opensearch.OpenSearch) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_OpenSearch_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.OpenSearch().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_OpenSearch_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "OpenSearch",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
 		},
 	}
 	return fc, nil
@@ -2810,42 +2777,6 @@ func (ec *executionContext) _OpenSearch(ctx context.Context, sel ast.SelectionSe
 					}
 				}()
 				res = ec._OpenSearch_team(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._OpenSearch_environment(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/postgres.generated.go
+++ b/internal/graph/gengql/postgres.generated.go
@@ -26,7 +26,6 @@ import (
 
 type PostgresInstanceResolver interface {
 	Team(ctx context.Context, obj *postgres.PostgresInstance) (*team.Team, error)
-	Environment(ctx context.Context, obj *postgres.PostgresInstance) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *postgres.PostgresInstance) (*team.TeamEnvironment, error)
 	Workloads(ctx context.Context, obj *postgres.PostgresInstance, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) (*pagination.Connection[workload.Workload], error)
 }
@@ -652,38 +651,6 @@ func (ec *executionContext) fieldContext_PostgresInstance_team(_ context.Context
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Team(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _PostgresInstance_environment(ctx context.Context, field graphql.CollectedField, obj *postgres.PostgresInstance) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_PostgresInstance_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.PostgresInstance().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_PostgresInstance_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "PostgresInstance",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
 		},
 	}
 	return fc, nil
@@ -2068,42 +2035,6 @@ func (ec *executionContext) _PostgresInstance(ctx context.Context, sel ast.Selec
 					}
 				}()
 				res = ec._PostgresInstance_team(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._PostgresInstance_environment(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -232,7 +232,6 @@ type ComplexityRoot struct {
 		Cost                      func(childComplexity int) int
 		DeletionStartedAt         func(childComplexity int) int
 		Deployments               func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) int
-		Environment               func(childComplexity int) int
 		History                   func(childComplexity int) int
 		ID                        func(childComplexity int) int
 		Image                     func(childComplexity int) int
@@ -431,7 +430,6 @@ type ComplexityRoot struct {
 		CascadingDelete func(childComplexity int) int
 		Cost            func(childComplexity int) int
 		Description     func(childComplexity int) int
-		Environment     func(childComplexity int) int
 		ID              func(childComplexity int) int
 		Labels          func(childComplexity int) int
 		Name            func(childComplexity int) int
@@ -490,7 +488,6 @@ type ComplexityRoot struct {
 
 	Bucket struct {
 		CascadingDelete          func(childComplexity int) int
-		Environment              func(childComplexity int) int
 		ID                       func(childComplexity int) int
 		Labels                   func(childComplexity int) int
 		Name                     func(childComplexity int) int
@@ -1161,7 +1158,6 @@ type ComplexityRoot struct {
 		Cost                      func(childComplexity int) int
 		DeletionStartedAt         func(childComplexity int) int
 		Deployments               func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) int
-		Environment               func(childComplexity int) int
 		ID                        func(childComplexity int) int
 		Image                     func(childComplexity int) int
 		ImageVulnerabilityHistory func(childComplexity int, from scalar.Date) int
@@ -1359,7 +1355,6 @@ type ComplexityRoot struct {
 	KafkaTopic struct {
 		ACL             func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *kafkatopic.KafkaTopicACLFilter, orderBy *kafkatopic.KafkaTopicACLOrder) int
 		Configuration   func(childComplexity int) int
-		Environment     func(childComplexity int) int
 		ID              func(childComplexity int) int
 		Labels          func(childComplexity int) int
 		Name            func(childComplexity int) int
@@ -1586,7 +1581,6 @@ type ComplexityRoot struct {
 		Access                func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, orderBy *opensearch.OpenSearchAccessOrder) int
 		ActivityLog           func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *activitylog.ActivityLogFilter) int
 		Cost                  func(childComplexity int) int
-		Environment           func(childComplexity int) int
 		ID                    func(childComplexity int) int
 		Issues                func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, orderBy *issue.IssueOrder, filter *issue.ResourceIssueFilter) int
 		Labels                func(childComplexity int) int
@@ -1780,7 +1774,6 @@ type ComplexityRoot struct {
 
 	PostgresInstance struct {
 		Audit             func(childComplexity int) int
-		Environment       func(childComplexity int) int
 		HighAvailability  func(childComplexity int) int
 		ID                func(childComplexity int) int
 		Labels            func(childComplexity int) int
@@ -2149,7 +2142,6 @@ type ComplexityRoot struct {
 	Secret struct {
 		ActivityLog     func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *activitylog.ActivityLogFilter) int
 		Applications    func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) int
-		Environment     func(childComplexity int) int
 		ID              func(childComplexity int) int
 		Jobs            func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) int
 		Keys            func(childComplexity int) int
@@ -2524,7 +2516,6 @@ type ComplexityRoot struct {
 		Charset         func(childComplexity int) int
 		Collation       func(childComplexity int) int
 		DeletionPolicy  func(childComplexity int) int
-		Environment     func(childComplexity int) int
 		Healthy         func(childComplexity int) int
 		ID              func(childComplexity int) int
 		Labels          func(childComplexity int) int
@@ -2542,7 +2533,6 @@ type ComplexityRoot struct {
 		Database            func(childComplexity int) int
 		DiskAutoresize      func(childComplexity int) int
 		DiskAutoresizeLimit func(childComplexity int) int
-		Environment         func(childComplexity int) int
 		Flags               func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) int
 		Healthy             func(childComplexity int) int
 		HighAvailability    func(childComplexity int) int
@@ -3082,7 +3072,6 @@ type ComplexityRoot struct {
 	}
 
 	TeamUtilizationData struct {
-		Environment     func(childComplexity int) int
 		Requested       func(childComplexity int) int
 		Team            func(childComplexity int) int
 		TeamEnvironment func(childComplexity int) int
@@ -3381,7 +3370,6 @@ type ComplexityRoot struct {
 		ActivityLog           func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *activitylog.ActivityLogFilter) int
 		Cost                  func(childComplexity int) int
 		Databases             func(childComplexity int) int
-		Environment           func(childComplexity int) int
 		ID                    func(childComplexity int) int
 		Issues                func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, orderBy *issue.IssueOrder, filter *issue.ResourceIssueFilter) int
 		Labels                func(childComplexity int) int
@@ -3944,13 +3932,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Application.Deployments(childComplexity, args["first"].(*int), args["after"].(*pagination.Cursor), args["last"].(*int), args["before"].(*pagination.Cursor)), true
-
-	case "Application.environment":
-		if e.ComplexityRoot.Application.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.Application.Environment(childComplexity), true
 
 	case "Application.history":
 		if e.ComplexityRoot.Application.History == nil {
@@ -4889,13 +4870,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.BigQueryDataset.Description(childComplexity), true
 
-	case "BigQueryDataset.environment":
-		if e.ComplexityRoot.BigQueryDataset.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.BigQueryDataset.Environment(childComplexity), true
-
 	case "BigQueryDataset.id":
 		if e.ComplexityRoot.BigQueryDataset.ID == nil {
 			break
@@ -5091,13 +5065,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Bucket.CascadingDelete(childComplexity), true
-
-	case "Bucket.environment":
-		if e.ComplexityRoot.Bucket.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.Bucket.Environment(childComplexity), true
 
 	case "Bucket.id":
 		if e.ComplexityRoot.Bucket.ID == nil {
@@ -7674,13 +7641,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Job.Deployments(childComplexity, args["first"].(*int), args["after"].(*pagination.Cursor), args["last"].(*int), args["before"].(*pagination.Cursor)), true
 
-	case "Job.environment":
-		if e.ComplexityRoot.Job.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.Job.Environment(childComplexity), true
-
 	case "Job.id":
 		if e.ComplexityRoot.Job.ID == nil {
 			break
@@ -8589,13 +8549,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.KafkaTopic.Configuration(childComplexity), true
-
-	case "KafkaTopic.environment":
-		if e.ComplexityRoot.KafkaTopic.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.KafkaTopic.Environment(childComplexity), true
 
 	case "KafkaTopic.id":
 		if e.ComplexityRoot.KafkaTopic.ID == nil {
@@ -9968,13 +9921,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.OpenSearch.Cost(childComplexity), true
 
-	case "OpenSearch.environment":
-		if e.ComplexityRoot.OpenSearch.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.OpenSearch.Environment(childComplexity), true
-
 	case "OpenSearch.id":
 		if e.ComplexityRoot.OpenSearch.ID == nil {
 			break
@@ -10789,13 +10735,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.PostgresInstance.Audit(childComplexity), true
-
-	case "PostgresInstance.environment":
-		if e.ComplexityRoot.PostgresInstance.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.PostgresInstance.Environment(childComplexity), true
 
 	case "PostgresInstance.highAvailability":
 		if e.ComplexityRoot.PostgresInstance.HighAvailability == nil {
@@ -12447,13 +12386,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Secret.Applications(childComplexity, args["first"].(*int), args["after"].(*pagination.Cursor), args["last"].(*int), args["before"].(*pagination.Cursor)), true
-
-	case "Secret.environment":
-		if e.ComplexityRoot.Secret.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.Secret.Environment(childComplexity), true
 
 	case "Secret.id":
 		if e.ComplexityRoot.Secret.ID == nil {
@@ -14111,13 +14043,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.SqlDatabase.DeletionPolicy(childComplexity), true
 
-	case "SqlDatabase.environment":
-		if e.ComplexityRoot.SqlDatabase.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.SqlDatabase.Environment(childComplexity), true
-
 	case "SqlDatabase.healthy":
 		if e.ComplexityRoot.SqlDatabase.Healthy == nil {
 			break
@@ -14215,13 +14140,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.SqlInstance.DiskAutoresizeLimit(childComplexity), true
-
-	case "SqlInstance.environment":
-		if e.ComplexityRoot.SqlInstance.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.SqlInstance.Environment(childComplexity), true
 
 	case "SqlInstance.flags":
 		if e.ComplexityRoot.SqlInstance.Flags == nil {
@@ -16640,13 +16558,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.TeamUpdatedActivityLogEntryDataUpdatedField.OldValue(childComplexity), true
 
-	case "TeamUtilizationData.environment":
-		if e.ComplexityRoot.TeamUtilizationData.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.TeamUtilizationData.Environment(childComplexity), true
-
 	case "TeamUtilizationData.requested":
 		if e.ComplexityRoot.TeamUtilizationData.Requested == nil {
 			break
@@ -17870,13 +17781,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Valkey.Databases(childComplexity), true
-
-	case "Valkey.environment":
-		if e.ComplexityRoot.Valkey.Environment == nil {
-			break
-		}
-
-		return e.ComplexityRoot.Valkey.Environment(childComplexity), true
 
 	case "Valkey.id":
 		if e.ComplexityRoot.Valkey.ID == nil {
@@ -20101,11 +20005,6 @@ type Application implements Node & Workload & ActivityLogger {
 	team: Team!
 
 	"""
-	The environment the application is deployed in.
-	"""
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
-
-	"""
 	The team environment for the application.
 	"""
 	teamEnvironment: TeamEnvironment!
@@ -21191,7 +21090,6 @@ type BigQueryDataset implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 	teamEnvironment: TeamEnvironment!
 	cascadingDelete: Boolean!
 	description: String
@@ -21362,7 +21260,6 @@ type Bucket implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 	teamEnvironment: TeamEnvironment!
 	cascadingDelete: Boolean!
 	publicAccessPrevention: String!
@@ -23492,9 +23389,6 @@ type Job implements Node & Workload & ActivityLogger {
 	"The team that owns the job."
 	team: Team!
 
-	"The environment the job is deployed in."
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
-
 	"The team environment for the job."
 	teamEnvironment: TeamEnvironment!
 
@@ -24188,7 +24082,6 @@ type KafkaTopic implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 	teamEnvironment: TeamEnvironment!
 	acl(
 		first: Int
@@ -24735,7 +24628,6 @@ type OpenSearch implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 	teamEnvironment: TeamEnvironment!
 	terminationProtection: Boolean!
 	state: OpenSearchState!
@@ -25143,7 +25035,6 @@ type CreateOpenSearchCredentialsPayload {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 	teamEnvironment: TeamEnvironment!
 	"User-defined labels attached to the resource."
 	labels: [ResourceLabel!]!
@@ -25277,7 +25168,6 @@ type PostgresInstance implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 	teamEnvironment: TeamEnvironment!
 	"Workloads that reference the Postgres instance."
 	workloads(
@@ -26402,9 +26292,6 @@ type Secret implements Node & ActivityLogger {
 
 	"The name of the secret."
 	name: String!
-
-	"The environment the secret exists in."
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 
 	"The environment the secret exists in."
 	teamEnvironment: TeamEnvironment!
@@ -28549,7 +28436,6 @@ type SqlDatabase implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 	teamEnvironment: TeamEnvironment!
 	charset: String
 	collation: String
@@ -28563,7 +28449,6 @@ type SqlInstance implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 	teamEnvironment: TeamEnvironment!
 	workload: Workload
 	cascadingDelete: Boolean!
@@ -30699,9 +30584,6 @@ type TeamUtilizationData {
 	used: Float!
 
 	"The environment for the utilization data."
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
-
-	"The environment for the utilization data."
 	teamEnvironment: TeamEnvironment!
 }
 
@@ -30776,7 +30658,6 @@ type Valkey implements Persistence & Node {
 	name: String!
 	terminationProtection: Boolean!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
 	teamEnvironment: TeamEnvironment!
 	"User-defined labels attached to the instance."
 	labels: [ResourceLabel!]!
@@ -32085,11 +31966,6 @@ interface Workload implements Node & ActivityLogger {
 	team: Team!
 
 	"""
-	The environment the workload is deployed in.
-	"""
-	environment: TeamEnvironment! @deprecated(reason: "Use the ` + "`" + `teamEnvironment` + "`" + ` field instead.")
-
-	"""
 	The team environment for the workload.
 	"""
 	teamEnvironment: TeamEnvironment!
@@ -32610,8 +32486,6 @@ func (ec *executionContext) childFields_Application(ctx context.Context, field g
 		return ec.fieldContext_Application_name(ctx, field)
 	case "team":
 		return ec.fieldContext_Application_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_Application_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_Application_teamEnvironment(ctx, field)
 	case "image":
@@ -32878,8 +32752,6 @@ func (ec *executionContext) childFields_BigQueryDataset(ctx context.Context, fie
 		return ec.fieldContext_BigQueryDataset_name(ctx, field)
 	case "team":
 		return ec.fieldContext_BigQueryDataset_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_BigQueryDataset_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_BigQueryDataset_teamEnvironment(ctx, field)
 	case "cascadingDelete":
@@ -33002,8 +32874,6 @@ func (ec *executionContext) childFields_Bucket(ctx context.Context, field graphq
 		return ec.fieldContext_Bucket_name(ctx, field)
 	case "team":
 		return ec.fieldContext_Bucket_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_Bucket_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_Bucket_teamEnvironment(ctx, field)
 	case "cascadingDelete":
@@ -34036,8 +33906,6 @@ func (ec *executionContext) childFields_Job(ctx context.Context, field graphql.C
 		return ec.fieldContext_Job_name(ctx, field)
 	case "team":
 		return ec.fieldContext_Job_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_Job_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_Job_teamEnvironment(ctx, field)
 	case "image":
@@ -34316,8 +34184,6 @@ func (ec *executionContext) childFields_KafkaTopic(ctx context.Context, field gr
 		return ec.fieldContext_KafkaTopic_name(ctx, field)
 	case "team":
 		return ec.fieldContext_KafkaTopic_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_KafkaTopic_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_KafkaTopic_teamEnvironment(ctx, field)
 	case "acl":
@@ -34548,8 +34414,6 @@ func (ec *executionContext) childFields_OpenSearch(ctx context.Context, field gr
 		return ec.fieldContext_OpenSearch_name(ctx, field)
 	case "team":
 		return ec.fieldContext_OpenSearch_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_OpenSearch_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_OpenSearch_teamEnvironment(ctx, field)
 	case "terminationProtection":
@@ -34808,8 +34672,6 @@ func (ec *executionContext) childFields_PostgresInstance(ctx context.Context, fi
 		return ec.fieldContext_PostgresInstance_name(ctx, field)
 	case "team":
 		return ec.fieldContext_PostgresInstance_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_PostgresInstance_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_PostgresInstance_teamEnvironment(ctx, field)
 	case "workloads":
@@ -35262,8 +35124,6 @@ func (ec *executionContext) childFields_Secret(ctx context.Context, field graphq
 		return ec.fieldContext_Secret_id(ctx, field)
 	case "name":
 		return ec.fieldContext_Secret_name(ctx, field)
-	case "environment":
-		return ec.fieldContext_Secret_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_Secret_teamEnvironment(ctx, field)
 	case "team":
@@ -35638,8 +35498,6 @@ func (ec *executionContext) childFields_SqlDatabase(ctx context.Context, field g
 		return ec.fieldContext_SqlDatabase_name(ctx, field)
 	case "team":
 		return ec.fieldContext_SqlDatabase_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_SqlDatabase_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_SqlDatabase_teamEnvironment(ctx, field)
 	case "charset":
@@ -35664,8 +35522,6 @@ func (ec *executionContext) childFields_SqlInstance(ctx context.Context, field g
 		return ec.fieldContext_SqlInstance_name(ctx, field)
 	case "team":
 		return ec.fieldContext_SqlInstance_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_SqlInstance_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_SqlInstance_teamEnvironment(ctx, field)
 	case "workload":
@@ -36508,8 +36364,6 @@ func (ec *executionContext) childFields_TeamUtilizationData(ctx context.Context,
 		return ec.fieldContext_TeamUtilizationData_requested(ctx, field)
 	case "used":
 		return ec.fieldContext_TeamUtilizationData_used(ctx, field)
-	case "environment":
-		return ec.fieldContext_TeamUtilizationData_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_TeamUtilizationData_teamEnvironment(ctx, field)
 	}
@@ -36896,8 +36750,6 @@ func (ec *executionContext) childFields_Valkey(ctx context.Context, field graphq
 		return ec.fieldContext_Valkey_terminationProtection(ctx, field)
 	case "team":
 		return ec.fieldContext_Valkey_team(ctx, field)
-	case "environment":
-		return ec.fieldContext_Valkey_environment(ctx, field)
 	case "teamEnvironment":
 		return ec.fieldContext_Valkey_teamEnvironment(ctx, field)
 	case "labels":

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -31331,13 +31331,6 @@ input TeamVulnerabilitySummaryFilter {
 	Only return vulnerability summaries for the given environment.
 	"""
 	environmentName: String
-
-	"""
-	Deprecated: use environmentName instead.
-	Only one environment is supported if this list is used.
-	"""
-	environments: [String!]
-		@deprecated(reason: "Use environmentName instead. Only one value is supported.")
 }
 
 """

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -26095,11 +26095,6 @@ input SearchFilter {
 	query: String!
 
 	"""
-	The type of entities to search for. If not specified, all types will be searched.
-	"""
-	type: SearchType @deprecated(reason: "Use the 'types' field instead.")
-
-	"""
 	The types of entities to search for. If not specified, all types will be searched.
 	"""
 	types: [SearchType!]

--- a/internal/graph/gengql/search.generated.go
+++ b/internal/graph/gengql/search.generated.go
@@ -188,7 +188,7 @@ func (ec *executionContext) unmarshalInputSearchFilter(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"query", "type", "types", "teams"}
+	fieldsInOrder := [...]string{"query", "types", "teams"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -202,13 +202,6 @@ func (ec *executionContext) unmarshalInputSearchFilter(ctx context.Context, obj 
 				return it, err
 			}
 			it.Query = data
-		case "type":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
-			data, err := ec.unmarshalOSearchType2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋsearchᚐSearchType(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Type = data
 		case "types":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("types"))
 			data, err := ec.unmarshalOSearchType2ᚕgithubᚗcomᚋnaisᚋapiᚋinternalᚋsearchᚐSearchTypeᚄ(ctx, v)
@@ -524,22 +517,6 @@ func (ec *executionContext) marshalOSearchType2ᚕgithubᚗcomᚋnaisᚋapiᚋin
 	}
 
 	return ret
-}
-
-func (ec *executionContext) unmarshalOSearchType2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋsearchᚐSearchType(ctx context.Context, v any) (*search.SearchType, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var res = new(search.SearchType)
-	err := res.UnmarshalGQL(v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOSearchType2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋsearchᚐSearchType(ctx context.Context, sel ast.SelectionSet, v *search.SearchType) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return v
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/internal/graph/gengql/secret.generated.go
+++ b/internal/graph/gengql/secret.generated.go
@@ -28,7 +28,6 @@ import (
 // region    ************************** generated!.gotpl **************************
 
 type SecretResolver interface {
-	Environment(ctx context.Context, obj *secret.Secret) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *secret.Secret) (*team.TeamEnvironment, error)
 	Team(ctx context.Context, obj *secret.Secret) (*team.Team, error)
 
@@ -378,38 +377,6 @@ func (ec *executionContext) _Secret_name(ctx context.Context, field graphql.Coll
 }
 func (ec *executionContext) fieldContext_Secret_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("Secret", field, false, false, errors.New("field of type String does not have child fields"))
-}
-
-func (ec *executionContext) _Secret_environment(ctx context.Context, field graphql.CollectedField, obj *secret.Secret) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Secret_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.Secret().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_Secret_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Secret",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
-		},
-	}
-	return fc, nil
 }
 
 func (ec *executionContext) _Secret_teamEnvironment(ctx context.Context, field graphql.CollectedField, obj *secret.Secret) (ret graphql.Marshaler) {
@@ -3526,42 +3493,6 @@ func (ec *executionContext) _Secret(ctx context.Context, sel ast.SelectionSet, o
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Secret_environment(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "teamEnvironment":
 			field := field
 

--- a/internal/graph/gengql/sqlinstance.generated.go
+++ b/internal/graph/gengql/sqlinstance.generated.go
@@ -25,12 +25,10 @@ import (
 
 type SqlDatabaseResolver interface {
 	Team(ctx context.Context, obj *sqlinstance.SQLDatabase) (*team.Team, error)
-	Environment(ctx context.Context, obj *sqlinstance.SQLDatabase) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *sqlinstance.SQLDatabase) (*team.TeamEnvironment, error)
 }
 type SqlInstanceResolver interface {
 	Team(ctx context.Context, obj *sqlinstance.SQLInstance) (*team.Team, error)
-	Environment(ctx context.Context, obj *sqlinstance.SQLInstance) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *sqlinstance.SQLInstance) (*team.TeamEnvironment, error)
 	Workload(ctx context.Context, obj *sqlinstance.SQLInstance) (workload.Workload, error)
 
@@ -305,38 +303,6 @@ func (ec *executionContext) fieldContext_SqlDatabase_team(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _SqlDatabase_environment(ctx context.Context, field graphql.CollectedField, obj *sqlinstance.SQLDatabase) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_SqlDatabase_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.SqlDatabase().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_SqlDatabase_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "SqlDatabase",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _SqlDatabase_teamEnvironment(ctx context.Context, field graphql.CollectedField, obj *sqlinstance.SQLDatabase) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -566,38 +532,6 @@ func (ec *executionContext) fieldContext_SqlInstance_team(_ context.Context, fie
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Team(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _SqlInstance_environment(ctx context.Context, field graphql.CollectedField, obj *sqlinstance.SQLInstance) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_SqlInstance_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.SqlInstance().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_SqlInstance_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "SqlInstance",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
 		},
 	}
 	return fc, nil
@@ -2832,42 +2766,6 @@ func (ec *executionContext) _SqlDatabase(ctx context.Context, sel ast.SelectionS
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._SqlDatabase_environment(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "teamEnvironment":
 			field := field
 
@@ -2974,42 +2872,6 @@ func (ec *executionContext) _SqlInstance(ctx context.Context, sel ast.SelectionS
 					}
 				}()
 				res = ec._SqlInstance_team(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._SqlInstance_environment(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/utilization.generated.go
+++ b/internal/graph/gengql/utilization.generated.go
@@ -26,7 +26,6 @@ type TeamServiceUtilizationResolver interface {
 type TeamUtilizationDataResolver interface {
 	Team(ctx context.Context, obj *utilization.TeamUtilizationData) (*team.Team, error)
 
-	Environment(ctx context.Context, obj *utilization.TeamUtilizationData) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *utilization.TeamUtilizationData) (*team.TeamEnvironment, error)
 }
 type WorkloadUtilizationResolver interface {
@@ -269,38 +268,6 @@ func (ec *executionContext) _TeamUtilizationData_used(ctx context.Context, field
 }
 func (ec *executionContext) fieldContext_TeamUtilizationData_used(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("TeamUtilizationData", field, false, false, errors.New("field of type Float does not have child fields"))
-}
-
-func (ec *executionContext) _TeamUtilizationData_environment(ctx context.Context, field graphql.CollectedField, obj *utilization.TeamUtilizationData) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_TeamUtilizationData_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.TeamUtilizationData().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_TeamUtilizationData_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "TeamUtilizationData",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
-		},
-	}
-	return fc, nil
 }
 
 func (ec *executionContext) _TeamUtilizationData_teamEnvironment(ctx context.Context, field graphql.CollectedField, obj *utilization.TeamUtilizationData) (ret graphql.Marshaler) {
@@ -1069,42 +1036,6 @@ func (ec *executionContext) _TeamUtilizationData(ctx context.Context, sel ast.Se
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._TeamUtilizationData_environment(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "teamEnvironment":
 			field := field
 

--- a/internal/graph/gengql/valkey.generated.go
+++ b/internal/graph/gengql/valkey.generated.go
@@ -29,7 +29,6 @@ import (
 
 type ValkeyResolver interface {
 	Team(ctx context.Context, obj *valkey.Valkey) (*team.Team, error)
-	Environment(ctx context.Context, obj *valkey.Valkey) (*team.TeamEnvironment, error)
 	TeamEnvironment(ctx context.Context, obj *valkey.Valkey) (*team.TeamEnvironment, error)
 
 	Access(ctx context.Context, obj *valkey.Valkey, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, orderBy *valkey.ValkeyAccessOrder) (*pagination.Connection[*valkey.ValkeyAccess], error)
@@ -444,38 +443,6 @@ func (ec *executionContext) fieldContext_Valkey_team(_ context.Context, field gr
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_Team(ctx, field)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Valkey_environment(ctx context.Context, field graphql.CollectedField, obj *valkey.Valkey) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_Valkey_environment(ctx, field)
-		},
-		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.Valkey().Environment(ctx, obj)
-		},
-		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v *team.TeamEnvironment) graphql.Marshaler {
-			return ec.marshalNTeamEnvironment2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋteamᚐTeamEnvironment(ctx, selections, v)
-		},
-		true,
-		true,
-	)
-}
-func (ec *executionContext) fieldContext_Valkey_environment(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Valkey",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.childFields_TeamEnvironment(ctx, field)
 		},
 	}
 	return fc, nil
@@ -2874,42 +2841,6 @@ func (ec *executionContext) _Valkey(ctx context.Context, sel ast.SelectionSet, o
 					}
 				}()
 				res = ec._Valkey_team(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
-		case "environment":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Valkey_environment(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/vulnerability.generated.go
+++ b/internal/graph/gengql/vulnerability.generated.go
@@ -3078,7 +3078,7 @@ func (ec *executionContext) unmarshalInputTeamVulnerabilitySummaryFilter(ctx con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"environmentName", "environments"}
+	fieldsInOrder := [...]string{"environmentName"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -3092,13 +3092,6 @@ func (ec *executionContext) unmarshalInputTeamVulnerabilitySummaryFilter(ctx con
 				return it, err
 			}
 			it.EnvironmentName = data
-		case "environments":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("environments"))
-			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Environments = data
 		}
 	}
 	return it, nil

--- a/internal/graph/jobs.resolvers.go
+++ b/internal/graph/jobs.resolvers.go
@@ -30,10 +30,6 @@ func (r *jobResolver) Team(ctx context.Context, obj *job.Job) (*team.Team, error
 	return team.Get(ctx, obj.TeamSlug)
 }
 
-func (r *jobResolver) Environment(ctx context.Context, obj *job.Job) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *jobResolver) TeamEnvironment(ctx context.Context, obj *job.Job) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }

--- a/internal/graph/kafka.resolvers.go
+++ b/internal/graph/kafka.resolvers.go
@@ -39,10 +39,6 @@ func (r *kafkaTopicResolver) Team(ctx context.Context, obj *kafkatopic.KafkaTopi
 	return team.Get(ctx, obj.TeamSlug)
 }
 
-func (r *kafkaTopicResolver) Environment(ctx context.Context, obj *kafkatopic.KafkaTopic) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *kafkaTopicResolver) TeamEnvironment(ctx context.Context, obj *kafkatopic.KafkaTopic) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }

--- a/internal/graph/opensearch.resolvers.go
+++ b/internal/graph/opensearch.resolvers.go
@@ -54,10 +54,6 @@ func (r *openSearchResolver) Team(ctx context.Context, obj *opensearch.OpenSearc
 	return team.Get(ctx, obj.TeamSlug)
 }
 
-func (r *openSearchResolver) Environment(ctx context.Context, obj *opensearch.OpenSearch) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *openSearchResolver) TeamEnvironment(ctx context.Context, obj *opensearch.OpenSearch) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }

--- a/internal/graph/postgres.resolvers.go
+++ b/internal/graph/postgres.resolvers.go
@@ -74,10 +74,6 @@ func (r *postgresInstanceResolver) Team(ctx context.Context, obj *postgres.Postg
 	return team.Get(ctx, obj.TeamSlug)
 }
 
-func (r *postgresInstanceResolver) Environment(ctx context.Context, obj *postgres.PostgresInstance) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *postgresInstanceResolver) TeamEnvironment(ctx context.Context, obj *postgres.PostgresInstance) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }

--- a/internal/graph/schema/applications.graphqls
+++ b/internal/graph/schema/applications.graphqls
@@ -134,11 +134,6 @@ type Application implements Node & Workload & ActivityLogger {
 	team: Team!
 
 	"""
-	The environment the application is deployed in.
-	"""
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
-
-	"""
 	The team environment for the application.
 	"""
 	teamEnvironment: TeamEnvironment!

--- a/internal/graph/schema/bigquery.graphqls
+++ b/internal/graph/schema/bigquery.graphqls
@@ -63,7 +63,6 @@ type BigQueryDataset implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
 	teamEnvironment: TeamEnvironment!
 	cascadingDelete: Boolean!
 	description: String

--- a/internal/graph/schema/bucket.graphqls
+++ b/internal/graph/schema/bucket.graphqls
@@ -63,7 +63,6 @@ type Bucket implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
 	teamEnvironment: TeamEnvironment!
 	cascadingDelete: Boolean!
 	publicAccessPrevention: String!

--- a/internal/graph/schema/jobs.graphqls
+++ b/internal/graph/schema/jobs.graphqls
@@ -88,9 +88,6 @@ type Job implements Node & Workload & ActivityLogger {
 	"The team that owns the job."
 	team: Team!
 
-	"The environment the job is deployed in."
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
-
 	"The team environment for the job."
 	teamEnvironment: TeamEnvironment!
 

--- a/internal/graph/schema/kafka.graphqls
+++ b/internal/graph/schema/kafka.graphqls
@@ -68,7 +68,6 @@ type KafkaTopic implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
 	teamEnvironment: TeamEnvironment!
 	acl(
 		first: Int

--- a/internal/graph/schema/opensearch.graphqls
+++ b/internal/graph/schema/opensearch.graphqls
@@ -61,7 +61,6 @@ type OpenSearch implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
 	teamEnvironment: TeamEnvironment!
 	terminationProtection: Boolean!
 	state: OpenSearchState!

--- a/internal/graph/schema/persistence.graphqls
+++ b/internal/graph/schema/persistence.graphqls
@@ -2,7 +2,6 @@ interface Persistence implements Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
 	teamEnvironment: TeamEnvironment!
 	"User-defined labels attached to the resource."
 	labels: [ResourceLabel!]!

--- a/internal/graph/schema/postgres.graphqls
+++ b/internal/graph/schema/postgres.graphqls
@@ -87,7 +87,6 @@ type PostgresInstance implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
 	teamEnvironment: TeamEnvironment!
 	"Workloads that reference the Postgres instance."
 	workloads(

--- a/internal/graph/schema/search.graphqls
+++ b/internal/graph/schema/search.graphqls
@@ -45,11 +45,6 @@ input SearchFilter {
 	query: String!
 
 	"""
-	The type of entities to search for. If not specified, all types will be searched.
-	"""
-	type: SearchType @deprecated(reason: "Use the 'types' field instead.")
-
-	"""
 	The types of entities to search for. If not specified, all types will be searched.
 	"""
 	types: [SearchType!]

--- a/internal/graph/schema/secret.graphqls
+++ b/internal/graph/schema/secret.graphqls
@@ -137,9 +137,6 @@ type Secret implements Node & ActivityLogger {
 	name: String!
 
 	"The environment the secret exists in."
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
-
-	"The environment the secret exists in."
 	teamEnvironment: TeamEnvironment!
 
 	"The team that owns the secret."

--- a/internal/graph/schema/sqlinstance.graphqls
+++ b/internal/graph/schema/sqlinstance.graphqls
@@ -91,7 +91,6 @@ type SqlDatabase implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
 	teamEnvironment: TeamEnvironment!
 	charset: String
 	collation: String
@@ -105,7 +104,6 @@ type SqlInstance implements Persistence & Node {
 	id: ID!
 	name: String!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
 	teamEnvironment: TeamEnvironment!
 	workload: Workload
 	cascadingDelete: Boolean!

--- a/internal/graph/schema/utilization.graphqls
+++ b/internal/graph/schema/utilization.graphqls
@@ -97,9 +97,6 @@ type TeamUtilizationData {
 	used: Float!
 
 	"The environment for the utilization data."
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
-
-	"The environment for the utilization data."
 	teamEnvironment: TeamEnvironment!
 }
 

--- a/internal/graph/schema/valkey.graphqls
+++ b/internal/graph/schema/valkey.graphqls
@@ -64,7 +64,6 @@ type Valkey implements Persistence & Node {
 	name: String!
 	terminationProtection: Boolean!
 	team: Team!
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
 	teamEnvironment: TeamEnvironment!
 	"User-defined labels attached to the instance."
 	labels: [ResourceLabel!]!

--- a/internal/graph/schema/vulnerability.graphqls
+++ b/internal/graph/schema/vulnerability.graphqls
@@ -248,13 +248,6 @@ input TeamVulnerabilitySummaryFilter {
 	Only return vulnerability summaries for the given environment.
 	"""
 	environmentName: String
-
-	"""
-	Deprecated: use environmentName instead.
-	Only one environment is supported if this list is used.
-	"""
-	environments: [String!]
-		@deprecated(reason: "Use environmentName instead. Only one value is supported.")
 }
 
 """

--- a/internal/graph/schema/workloads.graphqls
+++ b/internal/graph/schema/workloads.graphqls
@@ -99,11 +99,6 @@ interface Workload implements Node & ActivityLogger {
 	team: Team!
 
 	"""
-	The environment the workload is deployed in.
-	"""
-	environment: TeamEnvironment! @deprecated(reason: "Use the `teamEnvironment` field instead.")
-
-	"""
 	The team environment for the workload.
 	"""
 	teamEnvironment: TeamEnvironment!

--- a/internal/graph/secret.resolvers.go
+++ b/internal/graph/secret.resolvers.go
@@ -129,10 +129,6 @@ func (r *mutationResolver) ViewSecretValues(ctx context.Context, input secret.Vi
 	return secret.ViewSecretValues(ctx, input)
 }
 
-func (r *secretResolver) Environment(ctx context.Context, obj *secret.Secret) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *secretResolver) TeamEnvironment(ctx context.Context, obj *secret.Secret) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }

--- a/internal/graph/sqlinstance.resolvers.go
+++ b/internal/graph/sqlinstance.resolvers.go
@@ -39,20 +39,12 @@ func (r *sqlDatabaseResolver) Team(ctx context.Context, obj *sqlinstance.SQLData
 	return team.Get(ctx, obj.TeamSlug)
 }
 
-func (r *sqlDatabaseResolver) Environment(ctx context.Context, obj *sqlinstance.SQLDatabase) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *sqlDatabaseResolver) TeamEnvironment(ctx context.Context, obj *sqlinstance.SQLDatabase) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }
 
 func (r *sqlInstanceResolver) Team(ctx context.Context, obj *sqlinstance.SQLInstance) (*team.Team, error) {
 	return team.Get(ctx, obj.TeamSlug)
-}
-
-func (r *sqlInstanceResolver) Environment(ctx context.Context, obj *sqlinstance.SQLInstance) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
 }
 
 func (r *sqlInstanceResolver) TeamEnvironment(ctx context.Context, obj *sqlinstance.SQLInstance) (*team.TeamEnvironment, error) {

--- a/internal/graph/utilization.resolvers.go
+++ b/internal/graph/utilization.resolvers.go
@@ -42,10 +42,6 @@ func (r *teamUtilizationDataResolver) Team(ctx context.Context, obj *utilization
 	return team.Get(ctx, obj.TeamSlug)
 }
 
-func (r *teamUtilizationDataResolver) Environment(ctx context.Context, obj *utilization.TeamUtilizationData) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *teamUtilizationDataResolver) TeamEnvironment(ctx context.Context, obj *utilization.TeamUtilizationData) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, environmentmapper.EnvironmentName(obj.EnvironmentName))
 }

--- a/internal/graph/valkey.resolvers.go
+++ b/internal/graph/valkey.resolvers.go
@@ -73,10 +73,6 @@ func (r *valkeyResolver) Team(ctx context.Context, obj *valkey.Valkey) (*team.Te
 	return team.Get(ctx, obj.TeamSlug)
 }
 
-func (r *valkeyResolver) Environment(ctx context.Context, obj *valkey.Valkey) (*team.TeamEnvironment, error) {
-	return r.TeamEnvironment(ctx, obj)
-}
-
 func (r *valkeyResolver) TeamEnvironment(ctx context.Context, obj *valkey.Valkey) (*team.TeamEnvironment, error) {
 	return team.GetTeamEnvironment(ctx, obj.TeamSlug, obj.EnvironmentName)
 }

--- a/internal/search/bleve.go
+++ b/internal/search/bleve.go
@@ -186,10 +186,6 @@ func (b *bleveSearcher) Search(ctx context.Context, page *pagination.Pagination,
 		))
 	}
 
-	if filter.Type != nil {
-		filter.Types = append(filter.Types, *filter.Type)
-	}
-
 	if len(filter.Types) > 0 {
 		typesQuery := bleve.NewDisjunctionQuery()
 		for _, t := range filter.Types {
@@ -212,7 +208,8 @@ func (b *bleveSearcher) Search(ctx context.Context, page *pagination.Pagination,
 
 	var q query.Query = bleve.NewConjunctionQuery(queries...)
 
-	if len(slugs) > 0 && (filter.Type == nil || (filter.Type != nil && *filter.Type != "TEAM")) {
+	filteredByTeamOnly := len(filter.Types) == 1 && slices.Contains(filter.Types, "TEAM")
+	if len(slugs) > 0 && !filteredByTeamOnly {
 		teamSlugs := make([]string, 0, len(slugs))
 		for _, slug := range slugs {
 			teamSlugs = append(teamSlugs, slug.String())

--- a/internal/search/models.go
+++ b/internal/search/models.go
@@ -27,7 +27,6 @@ type Result struct {
 
 type SearchFilter struct {
 	Query string       `json:"query"`
-	Type  *SearchType  `json:"type,omitempty"`
 	Types []SearchType `json:"types,omitempty"`
 	Teams []slug.Slug  `json:"teams,omitempty"`
 }

--- a/internal/vulnerability/models.go
+++ b/internal/vulnerability/models.go
@@ -374,8 +374,7 @@ func (e ImageVulnerabilitySuppressionState) MarshalGQL(w io.Writer) {
 }
 
 type TeamVulnerabilitySummaryFilter struct {
-	EnvironmentName *string  `json:"environmentName,omitempty"`
-	Environments    []string `json:"environments,omitempty"`
+	EnvironmentName *string `json:"environmentName,omitempty"`
 }
 
 type ImageVulnerabilitySample struct {

--- a/internal/vulnerability/queries.go
+++ b/internal/vulnerability/queries.go
@@ -63,7 +63,7 @@ func ListWorkloadReferences(ctx context.Context, image string, page *pagination.
 
 func ListVulnerabilitySummaries(ctx context.Context, s slug.Slug, filter *TeamVulnerabilitySummaryFilter, page *pagination.Pagination, orderBy *VulnerabilitySummaryOrder) (*WorkloadVulnerabilitySummaryConnection, error) {
 	opts := make([]vulnerabilities.Option, 0)
-	if filter.EnvironmentName != nil {
+	if filter != nil && filter.EnvironmentName != nil {
 		opts = append(opts, vulnerabilities.ClusterFilter(environmentmapper.ClusterName(*filter.EnvironmentName)))
 	}
 	opts = append(opts, vulnerabilities.NamespaceFilter(s.String()))
@@ -510,7 +510,7 @@ func getVulnerabilityHistory(ctx context.Context, opts []vulnerabilities.Option)
 func GetVulnerabilitySummary(ctx context.Context, s slug.Slug, filter *TeamVulnerabilitySummaryFilter) (*TeamVulnerabilitySummary, error) {
 	opts := []vulnerabilities.Option{}
 	opts = append(opts, vulnerabilities.NamespaceFilter(s.String()))
-	if filter.EnvironmentName != nil {
+	if filter != nil && filter.EnvironmentName != nil {
 		opts = append(opts, vulnerabilities.ClusterFilter(environmentmapper.ClusterName(*filter.EnvironmentName)))
 	}
 

--- a/internal/vulnerability/queries.go
+++ b/internal/vulnerability/queries.go
@@ -63,12 +63,8 @@ func ListWorkloadReferences(ctx context.Context, image string, page *pagination.
 
 func ListVulnerabilitySummaries(ctx context.Context, s slug.Slug, filter *TeamVulnerabilitySummaryFilter, page *pagination.Pagination, orderBy *VulnerabilitySummaryOrder) (*WorkloadVulnerabilitySummaryConnection, error) {
 	opts := make([]vulnerabilities.Option, 0)
-	env, err := teamVulnerabilityFilterEnvironment(filter)
-	if err != nil {
-		return nil, err
-	}
-	if env != nil {
-		opts = append(opts, vulnerabilities.ClusterFilter(environmentmapper.ClusterName(*env)))
+	if filter.EnvironmentName != nil {
+		opts = append(opts, vulnerabilities.ClusterFilter(environmentmapper.ClusterName(*filter.EnvironmentName)))
 	}
 	opts = append(opts, vulnerabilities.NamespaceFilter(s.String()))
 	opts = append(opts, vulnerabilities.Offset(page.Offset()))
@@ -514,12 +510,8 @@ func getVulnerabilityHistory(ctx context.Context, opts []vulnerabilities.Option)
 func GetVulnerabilitySummary(ctx context.Context, s slug.Slug, filter *TeamVulnerabilitySummaryFilter) (*TeamVulnerabilitySummary, error) {
 	opts := []vulnerabilities.Option{}
 	opts = append(opts, vulnerabilities.NamespaceFilter(s.String()))
-	env, err := teamVulnerabilityFilterEnvironment(filter)
-	if err != nil {
-		return nil, err
-	}
-	if env != nil {
-		opts = append(opts, vulnerabilities.ClusterFilter(environmentmapper.ClusterName(*env)))
+	if filter.EnvironmentName != nil {
+		opts = append(opts, vulnerabilities.ClusterFilter(environmentmapper.ClusterName(*filter.EnvironmentName)))
 	}
 
 	resp, err := fromContext(ctx).manager.Client.GetVulnerabilitySummary(ctx, opts...)
@@ -550,26 +542,6 @@ func GetVulnerabilitySummary(ctx context.Context, s slug.Slug, filter *TeamVulne
 		SBOMCount:   int(resp.GetSbomCount()),
 		LastUpdated: lastUpdated,
 	}, nil
-}
-
-func teamVulnerabilityFilterEnvironment(filter *TeamVulnerabilitySummaryFilter) (*string, error) {
-	if filter == nil {
-		return nil, nil
-	}
-
-	if filter.EnvironmentName != nil {
-		return filter.EnvironmentName, nil
-	}
-
-	if len(filter.Environments) == 0 {
-		return nil, nil
-	}
-
-	if len(filter.Environments) > 1 {
-		return nil, apierror.Errorf("filter.environments supports only one value; use filter.environmentName")
-	}
-
-	return &filter.Environments[0], nil
 }
 
 func GetVulnerabilityMeanTimeToFixHistoryForWorkload(ctx context.Context, obj workload.Workload, from time.Time) (*VulnerabilityFixHistory, error) {


### PR DESCRIPTION
Remove the following fields:
- `environment: TeamEnvironment` 
- `TeamVulnerabilitySummaryFilter.environments`
- `SearchFilter.type`

According to our dashboard, they are no longer in use
