### PR TITLE
Support updating config values in UpdateConfig mutation

### DIFF
--- a/integration_tests/configs.lua
+++ b/integration_tests/configs.lua
@@ -1932,7 +1932,7 @@ end)
 Test.gql("Update config values - activity log records individual key changes", function(t)
 	t.addHeader("x-user-email", user:email())
 
-	-- Replace values: removes "app-name", adds "key-a" and "key-b"
+	-- Update with a single changed value: "app-name" goes from "my-app" to "updated-app"
 	t.query [[
 		mutation {
 			updateConfig(input: {
@@ -1940,8 +1940,7 @@ Test.gql("Update config values - activity log records individual key changes", f
 				environmentName: "dev"
 				teamSlug: "myteam"
 				values: [
-					{ name: "key-a", value: "val-a" }
-					{ name: "key-b", value: "val-b" }
+					{ name: "app-name", value: "updated-app" }
 				]
 			}) {
 				config {
@@ -1958,15 +1957,14 @@ Test.gql("Update config values - activity log records individual key changes", f
 				config = {
 					name = "config-labels-values",
 					values = {
-						{ name = "key-a", value = "val-a" },
-						{ name = "key-b", value = "val-b" },
+						{ name = "app-name", value = "updated-app" },
 					},
 				},
 			},
 		},
 	}
 
-	-- Verify activity log shows individual field changes
+	-- Verify activity log shows the individual field change
 	t.query [[
 		query {
 			team(slug: "myteam") {
@@ -1998,9 +1996,13 @@ Test.gql("Update config values - activity log records individual key changes", f
 							message = Contains("Updated config"),
 							resourceName = "config-labels-values",
 							data = {
-								updatedFields = Contains(
-									{ field = "key-a", oldValue = Null, newValue = "val-a" }
-								),
+								updatedFields = {
+									{
+										field = "app-name",
+										oldValue = "my-app",
+										newValue = "updated-app",
+									},
+								},
 							},
 						},
 					},

--- a/integration_tests/configs.lua
+++ b/integration_tests/configs.lua
@@ -1886,3 +1886,190 @@ Test.gql("Update config - mixed plain text and base64 values", function(t)
 		},
 	}
 end)
+
+Test.gql("Create config with labels and values", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			createConfig(input: {
+				name: "config-labels-values"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				labels: [
+					{ key: "team-label", value: "my-team" }
+				]
+				values: [
+					{ name: "app-name", value: "my-app" }
+				]
+			}) {
+				config {
+					name
+					labels { key value }
+					values { name value encoding }
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			createConfig = {
+				config = {
+					name = "config-labels-values",
+					labels = {
+						{ key = "team-label", value = "my-team" },
+					},
+					values = {
+						{ name = "app-name", value = "my-app", encoding = "PLAIN_TEXT" },
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Update config values - activity log records individual key changes", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	-- Replace values: removes "app-name", adds "key-a" and "key-b"
+	t.query [[
+		mutation {
+			updateConfig(input: {
+				name: "config-labels-values"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				values: [
+					{ name: "key-a", value: "val-a" }
+					{ name: "key-b", value: "val-b" }
+				]
+			}) {
+				config {
+					name
+					values { name value }
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateConfig = {
+				config = {
+					name = "config-labels-values",
+					values = {
+						{ name = "key-a", value = "val-a" },
+						{ name = "key-b", value = "val-b" },
+					},
+				},
+			},
+		},
+	}
+
+	-- Verify activity log shows individual field changes
+	t.query [[
+		query {
+			team(slug: "myteam") {
+				activityLog(first: 1, filter: { activityTypes: [CONFIG_UPDATED] }) {
+					nodes {
+						... on ConfigUpdatedActivityLogEntry {
+							message
+							resourceName
+							data {
+								updatedFields {
+									field
+									oldValue
+									newValue
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			team = {
+				activityLog = {
+					nodes = {
+						{
+							message = Contains("Updated config"),
+							resourceName = "config-labels-values",
+							data = {
+								updatedFields = Contains(
+									{ field = "key-a", oldValue = Null, newValue = "val-a" }
+								),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Create config with invalid base64 value fails", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			createConfig(input: {
+				name: "config-invalid-b64"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				values: [
+					{ name: "bad", value: "not-valid-base64!!!", encoding: BASE64 }
+				]
+			}) {
+				config { name }
+			}
+		}
+	]]
+
+	t.check {
+		errors = {
+			{
+				locations = NotNull(),
+				message = Contains("not valid base64"),
+				path = {
+					"createConfig",
+				},
+			},
+		},
+		data = Null,
+	}
+end)
+
+Test.gql("Update config with invalid base64 value fails", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateConfig(input: {
+				name: "config-labels-values"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				values: [
+					{ name: "bad-cert", value: "%%%invalid%%%", encoding: BASE64 }
+				]
+			}) {
+				config { name }
+			}
+		}
+	]]
+
+	t.check {
+		errors = {
+			{
+				locations = NotNull(),
+				message = Contains("not valid base64"),
+				path = {
+					"updateConfig",
+				},
+			},
+		},
+		data = Null,
+	}
+end)

--- a/integration_tests/configs.lua
+++ b/integration_tests/configs.lua
@@ -1879,7 +1879,7 @@ Test.gql("Update config - mixed plain text and base64 values", function(t)
 					name = "config-with-values",
 					values = {
 						{ name = "binary", value = "d29ybGQ=", encoding = "BASE64" },
-						{ name = "plain", value = "hello", encoding = "PLAIN_TEXT" },
+						{ name = "plain",  value = "hello",    encoding = "PLAIN_TEXT" },
 					},
 				},
 			},

--- a/integration_tests/configs.lua
+++ b/integration_tests/configs.lua
@@ -1645,3 +1645,244 @@ Test.k8s("Validate config labels after update", function(t)
 		},
 	})
 end)
+
+Test.gql("Create config with initial values", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			createConfig(input: {
+				name: "config-with-values"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				values: [
+					{ name: "key1", value: "val1" }
+					{ name: "key2", value: "val2" }
+				]
+			}) {
+				config {
+					name
+					values {
+						name
+						value
+						encoding
+					}
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			createConfig = {
+				config = {
+					name = "config-with-values",
+					values = {
+						{ name = "key1", value = "val1", encoding = "PLAIN_TEXT" },
+						{ name = "key2", value = "val2", encoding = "PLAIN_TEXT" },
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Create config with initial binary value", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			createConfig(input: {
+				name: "config-with-binary"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				values: [
+					{ name: "cert", value: "dGVzdA==", encoding: BASE64 }
+				]
+			}) {
+				config {
+					name
+					values {
+						name
+						value
+						encoding
+					}
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			createConfig = {
+				config = {
+					name = "config-with-binary",
+					values = {
+						{ name = "cert", value = "dGVzdA==", encoding = "BASE64" },
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Update config - replace all values", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateConfig(input: {
+				name: "config-with-values"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				values: [
+					{ name: "new-key", value: "new-val" }
+				]
+			}) {
+				config {
+					name
+					values {
+						name
+						value
+						encoding
+					}
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateConfig = {
+				config = {
+					name = "config-with-values",
+					values = {
+						{ name = "new-key", value = "new-val", encoding = "PLAIN_TEXT" },
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Update config - null values leaves existing values unchanged", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	-- Update only labels, values should remain unchanged
+	t.query [[
+		mutation {
+			updateConfig(input: {
+				name: "config-with-values"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				labels: [
+					{ key: "some-label", value: "some-value" }
+				]
+			}) {
+				config {
+					name
+					values {
+						name
+						value
+						encoding
+					}
+					labels {
+						key
+						value
+					}
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateConfig = {
+				config = {
+					name = "config-with-values",
+					values = {
+						{ name = "new-key", value = "new-val", encoding = "PLAIN_TEXT" },
+					},
+					labels = {
+						{ key = "some-label", value = "some-value" },
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Update config - empty values list removes all values", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateConfig(input: {
+				name: "config-with-values"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				values: []
+			}) {
+				config {
+					name
+					values {
+						name
+						value
+					}
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateConfig = {
+				config = {
+					name = "config-with-values",
+					values = {},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Update config - mixed plain text and base64 values", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query [[
+		mutation {
+			updateConfig(input: {
+				name: "config-with-values"
+				environmentName: "dev"
+				teamSlug: "myteam"
+				values: [
+					{ name: "plain", value: "hello" }
+					{ name: "binary", value: "d29ybGQ=", encoding: BASE64 }
+				]
+			}) {
+				config {
+					name
+					values {
+						name
+						value
+						encoding
+					}
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			updateConfig = {
+				config = {
+					name = "config-with-values",
+					values = {
+						{ name = "binary", value = "d29ybGQ=", encoding = "BASE64" },
+						{ name = "plain", value = "hello", encoding = "PLAIN_TEXT" },
+					},
+				},
+			},
+		},
+	}
+end)

--- a/internal/graph/config.resolvers.go
+++ b/internal/graph/config.resolvers.go
@@ -178,7 +178,7 @@ func (r *mutationResolver) UpdateConfig(ctx context.Context, input config.Update
 		return nil, err
 	}
 
-	c, err := config.UpdateLabels(ctx, input.TeamSlug, input.EnvironmentName, input.Name, input.Labels)
+	c, err := config.Update(ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/graph/config.resolvers.go
+++ b/internal/graph/config.resolvers.go
@@ -163,7 +163,7 @@ func (r *mutationResolver) CreateConfig(ctx context.Context, input config.Create
 		return nil, err
 	}
 
-	c, err := config.Create(ctx, input.TeamSlug, input.EnvironmentName, input.Name)
+	c, err := config.Create(ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/graph/gengql/config.generated.go
+++ b/internal/graph/gengql/config.generated.go
@@ -2062,7 +2062,7 @@ func (ec *executionContext) unmarshalInputCreateConfigInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "environmentName", "teamSlug", "values"}
+	fieldsInOrder := [...]string{"name", "environmentName", "teamSlug", "labels", "values"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -2090,6 +2090,13 @@ func (ec *executionContext) unmarshalInputCreateConfigInput(ctx context.Context,
 				return it, err
 			}
 			it.TeamSlug = data
+		case "labels":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("labels"))
+			data, err := ec.unmarshalOResourceLabelInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋgraphᚋmodelᚐResourceLabelᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Labels = data
 		case "values":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("values"))
 			data, err := ec.unmarshalOConfigValueInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋconfigᚐConfigValueInputᚄ(ctx, v)

--- a/internal/graph/gengql/config.generated.go
+++ b/internal/graph/gengql/config.generated.go
@@ -2062,7 +2062,7 @@ func (ec *executionContext) unmarshalInputCreateConfigInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "environmentName", "teamSlug"}
+	fieldsInOrder := [...]string{"name", "environmentName", "teamSlug", "values"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -2090,6 +2090,13 @@ func (ec *executionContext) unmarshalInputCreateConfigInput(ctx context.Context,
 				return it, err
 			}
 			it.TeamSlug = data
+		case "values":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("values"))
+			data, err := ec.unmarshalOConfigValueInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋconfigᚐConfigValueInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Values = data
 		}
 	}
 	return it, nil
@@ -2231,7 +2238,7 @@ func (ec *executionContext) unmarshalInputUpdateConfigInput(ctx context.Context,
 			it.TeamSlug = data
 		case "labels":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("labels"))
-			data, err := ec.unmarshalNResourceLabelInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋgraphᚋmodelᚐResourceLabelᚄ(ctx, v)
+			data, err := ec.unmarshalOResourceLabelInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋgraphᚋmodelᚐResourceLabelᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/internal/graph/gengql/config.generated.go
+++ b/internal/graph/gengql/config.generated.go
@@ -2201,7 +2201,7 @@ func (ec *executionContext) unmarshalInputUpdateConfigInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "environmentName", "teamSlug", "labels"}
+	fieldsInOrder := [...]string{"name", "environmentName", "teamSlug", "labels", "values"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -2236,6 +2236,13 @@ func (ec *executionContext) unmarshalInputUpdateConfigInput(ctx context.Context,
 				return it, err
 			}
 			it.Labels = data
+		case "values":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("values"))
+			data, err := ec.unmarshalOConfigValueInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋconfigᚐConfigValueInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Values = data
 		}
 	}
 	return it, nil
@@ -3809,6 +3816,24 @@ func (ec *executionContext) unmarshalOConfigOrder2ᚖgithubᚗcomᚋnaisᚋapi�
 	}
 	res, err := ec.unmarshalInputConfigOrder(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOConfigValueInput2ᚕᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋconfigᚐConfigValueInputᚄ(ctx context.Context, v any) ([]*config.ConfigValueInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]*config.ConfigValueInput, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNConfigValueInput2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚋconfigᚐConfigValueInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 // endregion ***************************** type.gotpl *****************************

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -21799,6 +21799,9 @@ input UpdateConfigInput {
 
 	"The complete set of user-defined labels to apply. Existing user-defined labels are replaced; send an empty list to remove all labels."
 	labels: [ResourceLabelInput!]!
+
+	"The complete set of config values. When set, replaces all existing data and binaryData entries; use an empty list to remove all values. When null, existing values are left unchanged. The encoding field on each value determines whether it is stored as plain-text data or binary data."
+	values: [ConfigValueInput!]
 }
 
 type UpdateConfigPayload {

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -21727,6 +21727,9 @@ input CreateConfigInput {
 
 	"The team that owns the config."
 	teamSlug: Slug!
+
+	"Initial config values. The encoding field on each value determines whether it is stored as plain-text data or binary data."
+	values: [ConfigValueInput!]
 }
 
 input AddConfigValueInput {
@@ -21797,8 +21800,8 @@ input UpdateConfigInput {
 	"The team that owns the config."
 	teamSlug: Slug!
 
-	"The complete set of user-defined labels to apply. Existing user-defined labels are replaced; send an empty list to remove all labels."
-	labels: [ResourceLabelInput!]!
+	"The complete set of user-defined labels to apply. When set, existing user-defined labels are replaced; use an empty list to remove all labels. When null, existing labels are left unchanged."
+	labels: [ResourceLabelInput!]
 
 	"The complete set of config values. When set, replaces all existing data and binaryData entries; use an empty list to remove all values. When null, existing values are left unchanged. The encoding field on each value determines whether it is stored as plain-text data or binary data."
 	values: [ConfigValueInput!]

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -21728,6 +21728,9 @@ input CreateConfigInput {
 	"The team that owns the config."
 	teamSlug: Slug!
 
+	"Initial user-defined labels to apply."
+	labels: [ResourceLabelInput!]
+
 	"Initial config values. The encoding field on each value determines whether it is stored as plain-text data or binary data."
 	values: [ConfigValueInput!]
 }
@@ -21803,7 +21806,7 @@ input UpdateConfigInput {
 	"The complete set of user-defined labels to apply. When set, existing user-defined labels are replaced; use an empty list to remove all labels. When null, existing labels are left unchanged."
 	labels: [ResourceLabelInput!]
 
-	"The complete set of config values. When set, replaces all existing data and binaryData entries; use an empty list to remove all values. When null, existing values are left unchanged. The encoding field on each value determines whether it is stored as plain-text data or binary data."
+	"The complete set of config values. When set, replaces all existing values; use an empty list to remove all values. When null, existing values are left unchanged. The encoding field on each value determines whether it is stored as plain text or binary (base64-encoded)."
 	values: [ConfigValueInput!]
 }
 

--- a/internal/graph/schema/config.graphqls
+++ b/internal/graph/schema/config.graphqls
@@ -250,6 +250,9 @@ input CreateConfigInput {
 	"The team that owns the config."
 	teamSlug: Slug!
 
+	"Initial user-defined labels to apply."
+	labels: [ResourceLabelInput!]
+
 	"Initial config values. The encoding field on each value determines whether it is stored as plain-text data or binary data."
 	values: [ConfigValueInput!]
 }
@@ -325,7 +328,7 @@ input UpdateConfigInput {
 	"The complete set of user-defined labels to apply. When set, existing user-defined labels are replaced; use an empty list to remove all labels. When null, existing labels are left unchanged."
 	labels: [ResourceLabelInput!]
 
-	"The complete set of config values. When set, replaces all existing data and binaryData entries; use an empty list to remove all values. When null, existing values are left unchanged. The encoding field on each value determines whether it is stored as plain-text data or binary data."
+	"The complete set of config values. When set, replaces all existing values; use an empty list to remove all values. When null, existing values are left unchanged. The encoding field on each value determines whether it is stored as plain text or binary (base64-encoded)."
 	values: [ConfigValueInput!]
 }
 

--- a/internal/graph/schema/config.graphqls
+++ b/internal/graph/schema/config.graphqls
@@ -321,6 +321,9 @@ input UpdateConfigInput {
 
 	"The complete set of user-defined labels to apply. Existing user-defined labels are replaced; send an empty list to remove all labels."
 	labels: [ResourceLabelInput!]!
+
+	"The complete set of config values. When set, replaces all existing data and binaryData entries; use an empty list to remove all values. When null, existing values are left unchanged. The encoding field on each value determines whether it is stored as plain-text data or binary data."
+	values: [ConfigValueInput!]
 }
 
 type UpdateConfigPayload {

--- a/internal/graph/schema/config.graphqls
+++ b/internal/graph/schema/config.graphqls
@@ -249,6 +249,9 @@ input CreateConfigInput {
 
 	"The team that owns the config."
 	teamSlug: Slug!
+
+	"Initial config values. The encoding field on each value determines whether it is stored as plain-text data or binary data."
+	values: [ConfigValueInput!]
 }
 
 input AddConfigValueInput {
@@ -319,8 +322,8 @@ input UpdateConfigInput {
 	"The team that owns the config."
 	teamSlug: Slug!
 
-	"The complete set of user-defined labels to apply. Existing user-defined labels are replaced; send an empty list to remove all labels."
-	labels: [ResourceLabelInput!]!
+	"The complete set of user-defined labels to apply. When set, existing user-defined labels are replaced; use an empty list to remove all labels. When null, existing labels are left unchanged."
+	labels: [ResourceLabelInput!]
 
 	"The complete set of config values. When set, replaces all existing data and binaryData entries; use an empty list to remove all values. When null, existing values are left unchanged. The encoding field on each value determines whether it is stored as plain-text data or binary data."
 	values: [ConfigValueInput!]

--- a/internal/workload/config/models.go
+++ b/internal/workload/config/models.go
@@ -35,10 +35,11 @@ type Config struct {
 }
 
 type CreateConfigInput struct {
-	Name            string              `json:"name"`
-	EnvironmentName string              `json:"environmentName"`
-	TeamSlug        slug.Slug           `json:"teamSlug"`
-	Values          []*ConfigValueInput `json:"values"`
+	Name            string                 `json:"name"`
+	EnvironmentName string                 `json:"environmentName"`
+	TeamSlug        slug.Slug              `json:"teamSlug"`
+	Labels          []*model.ResourceLabel `json:"labels"`
+	Values          []*ConfigValueInput    `json:"values"`
 }
 
 type CreateConfigPayload struct {

--- a/internal/workload/config/models.go
+++ b/internal/workload/config/models.go
@@ -35,9 +35,10 @@ type Config struct {
 }
 
 type CreateConfigInput struct {
-	Name            string    `json:"name"`
-	EnvironmentName string    `json:"environmentName"`
-	TeamSlug        slug.Slug `json:"teamSlug"`
+	Name            string              `json:"name"`
+	EnvironmentName string              `json:"environmentName"`
+	TeamSlug        slug.Slug           `json:"teamSlug"`
+	Values          []*ConfigValueInput `json:"values"`
 }
 
 type CreateConfigPayload struct {

--- a/internal/workload/config/models.go
+++ b/internal/workload/config/models.go
@@ -49,6 +49,7 @@ type UpdateConfigInput struct {
 	EnvironmentName string                 `json:"environmentName"`
 	TeamSlug        slug.Slug              `json:"teamSlug"`
 	Labels          []*model.ResourceLabel `json:"labels"`
+	Values          []*ConfigValueInput    `json:"values"`
 }
 
 type UpdateConfigPayload struct {

--- a/internal/workload/config/queries.go
+++ b/internal/workload/config/queries.go
@@ -510,19 +510,28 @@ func RemoveConfigValue(ctx context.Context, teamSlug slug.Slug, environment, con
 	return retVal, nil
 }
 
-func UpdateLabels(ctx context.Context, teamSlug slug.Slug, environment, name string, labels []*model.ResourceLabel) (*Config, error) {
-	if err := model.ValidateUserLabels(labels); err != nil {
+func Update(ctx context.Context, input UpdateConfigInput) (*Config, error) {
+	if err := model.ValidateUserLabels(input.Labels); err != nil {
 		return nil, err
 	}
 
+	// Validate values
+	if input.Values != nil {
+		for _, v := range input.Values {
+			if err := validateConfigValue(v); err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	w := fromContext(ctx).Watcher()
-	client, err := w.ImpersonatedClient(ctx, environment)
+	client, err := w.ImpersonatedClient(ctx, input.EnvironmentName)
 	if err != nil {
 		return nil, err
 	}
 
 	// Check if the config exists and is managed by console
-	obj, err := client.Namespace(teamSlug.String()).Get(ctx, name, v1.GetOptions{})
+	obj, err := client.Namespace(input.TeamSlug.String()).Get(ctx, input.Name, v1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -531,35 +540,73 @@ func UpdateLabels(ctx context.Context, teamSlug slug.Slug, environment, name str
 		return nil, ErrUnmanaged
 	}
 
+	actor := authz.ActorFromContext(ctx)
+	mergedAnnotations := mergeAnnotations(obj.GetAnnotations(), actor.User.Identity(), nil)
+
+	// Build patch operations
+	var patch []map[string]any
+	var updatedFields []*ConfigUpdatedActivityLogEntryDataUpdatedField
+
+	// Labels
 	existingLabels := obj.GetLabels()
-	mergedLabels := model.MergeUserLabels(existingLabels, labels)
+	mergedLabels := model.MergeUserLabels(existingLabels, input.Labels)
+	if !maps.Equal(mergedLabels, existingLabels) {
+		patch = append(patch, map[string]any{"op": "replace", "path": "/metadata/labels", "value": mergedLabels})
+		oldValue := model.FormatUserLabels(model.UserLabels(existingLabels))
+		newValue := model.FormatUserLabels(model.UserLabels(mergedLabels))
+		updatedFields = append(updatedFields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
+			Field:    "labels",
+			OldValue: &oldValue,
+			NewValue: &newValue,
+		})
+	}
+
+	// Values — split into data (plain text) and binaryData (base64) based on encoding
+	if input.Values != nil {
+		newData := make(map[string]any)
+		newBinaryData := make(map[string]any)
+
+		for _, v := range input.Values {
+			encodedValue, err := encodeValueForStorage(v)
+			if err != nil {
+				return nil, err
+			}
+
+			isBinary := v.Encoding != nil && *v.Encoding == secret.ValueEncodingBase64
+			if isBinary {
+				newBinaryData[v.Name] = encodedValue
+			} else {
+				newData[v.Name] = encodedValue
+			}
+		}
+
+		patch = append(patch,
+			map[string]any{"op": "replace", "path": "/data", "value": newData},
+			map[string]any{"op": "replace", "path": "/binaryData", "value": newBinaryData},
+		)
+		updatedFields = append(updatedFields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
+			Field: "values",
+		})
+	}
 
 	// Nothing changed — return the current state without writing.
-	if maps.Equal(mergedLabels, existingLabels) {
-		retVal, ok := toGraphConfig(obj, environment)
+	if len(patch) == 0 {
+		retVal, ok := toGraphConfig(obj, input.EnvironmentName)
 		if !ok {
 			return nil, fmt.Errorf("failed to convert config")
 		}
 		return retVal, nil
 	}
 
-	oldValue := model.FormatUserLabels(model.UserLabels(existingLabels))
-	newValue := model.FormatUserLabels(model.UserLabels(mergedLabels))
-
-	actor := authz.ActorFromContext(ctx)
-	mergedAnnotations := mergeAnnotations(obj.GetAnnotations(), actor.User.Identity(), nil)
-
-	patch := []map[string]any{
-		{"op": "replace", "path": "/metadata/labels", "value": mergedLabels},
-		{"op": "replace", "path": "/metadata/annotations", "value": mergedAnnotations},
-	}
+	// Always update annotations when something changed
+	patch = append(patch, map[string]any{"op": "replace", "path": "/metadata/annotations", "value": mergedAnnotations})
 
 	patchBytes, err := json.Marshal(patch)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling patch: %w", err)
 	}
 
-	_, err = client.Namespace(teamSlug.String()).Patch(ctx, name, types.JSONPatchType, patchBytes, v1.PatchOptions{})
+	_, err = client.Namespace(input.TeamSlug.String()).Patch(ctx, input.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("patching config: %w", err)
 	}
@@ -567,18 +614,12 @@ func UpdateLabels(ctx context.Context, teamSlug slug.Slug, environment, name str
 	err = activitylog.Create(ctx, activitylog.CreateInput{
 		Action:          activitylog.ActivityLogEntryActionUpdated,
 		Actor:           actor.User,
-		EnvironmentName: &environment,
+		EnvironmentName: &input.EnvironmentName,
 		ResourceType:    activityLogEntryResourceTypeConfig,
-		ResourceName:    name,
-		TeamSlug:        &teamSlug,
+		ResourceName:    input.Name,
+		TeamSlug:        &input.TeamSlug,
 		Data: ConfigUpdatedActivityLogEntryData{
-			UpdatedFields: []*ConfigUpdatedActivityLogEntryDataUpdatedField{
-				{
-					Field:    "labels",
-					OldValue: &oldValue,
-					NewValue: &newValue,
-				},
-			},
+			UpdatedFields: updatedFields,
 		},
 	})
 	if err != nil {
@@ -586,16 +627,25 @@ func UpdateLabels(ctx context.Context, teamSlug slug.Slug, environment, name str
 	}
 
 	// Re-fetch from the K8s API to return up-to-date data
-	updated, err := client.Namespace(teamSlug.String()).Get(ctx, name, v1.GetOptions{})
+	updated, err := client.Namespace(input.TeamSlug.String()).Get(ctx, input.Name, v1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("fetching updated config: %w", err)
 	}
 
-	retVal, ok := toGraphConfig(updated, environment)
+	retVal, ok := toGraphConfig(updated, input.EnvironmentName)
 	if !ok {
 		return nil, fmt.Errorf("failed to convert config")
 	}
 	return retVal, nil
+}
+
+func UpdateLabels(ctx context.Context, teamSlug slug.Slug, environment, name string, labels []*model.ResourceLabel) (*Config, error) {
+	return Update(ctx, UpdateConfigInput{
+		Name:            name,
+		EnvironmentName: environment,
+		TeamSlug:        teamSlug,
+		Labels:          labels,
+	})
 }
 
 func Delete(ctx context.Context, teamSlug slug.Slug, environment, name string) error {

--- a/internal/workload/config/queries.go
+++ b/internal/workload/config/queries.go
@@ -783,7 +783,7 @@ func encodeValueForStorage(input *ConfigValueInput) (string, error) {
 	case secret.ValueEncodingBase64:
 		// Validate that the value is valid base64
 		if _, err := base64.StdEncoding.DecodeString(input.Value); err != nil {
-			return "", fmt.Errorf("value is not valid base64: %w", err)
+			return "", apierror.Errorf("Value for key %q is not valid base64.", input.Name)
 		}
 		// The value is already base64-encoded, which is what Kubernetes binaryData expects
 		return input.Value, nil

--- a/internal/workload/config/queries.go
+++ b/internal/workload/config/queries.go
@@ -112,25 +112,61 @@ func configValuesFromConfig(config *Config) []*ConfigValue {
 	return values
 }
 
-func Create(ctx context.Context, teamSlug slug.Slug, environment, name string) (*Config, error) {
+func Create(ctx context.Context, input CreateConfigInput) (*Config, error) {
 	w := fromContext(ctx).Watcher()
-	client, err := w.ImpersonatedClient(ctx, environment)
+	client, err := w.ImpersonatedClient(ctx, input.EnvironmentName)
 	if err != nil {
 		return nil, err
 	}
 
-	if nameErrs := validation.IsDNS1123Subdomain(name); len(nameErrs) > 0 {
-		return nil, fmt.Errorf("invalid name %q: %s", name, strings.Join(nameErrs, ", "))
+	if nameErrs := validation.IsDNS1123Subdomain(input.Name); len(nameErrs) > 0 {
+		return nil, fmt.Errorf("invalid name %q: %s", input.Name, strings.Join(nameErrs, ", "))
+	}
+
+	// Validate values
+	if input.Values != nil {
+		for _, v := range input.Values {
+			if err := validateConfigValue(v); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	actor := authz.ActorFromContext(ctx)
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{
-			Name:        name,
-			Namespace:   teamSlug.String(),
+			Name:        input.Name,
+			Namespace:   input.TeamSlug.String(),
 			Annotations: annotations(actor.User.Identity()),
 		},
+	}
+
+	// Populate data and binaryData from values
+	if input.Values != nil {
+		data := make(map[string]string)
+		binaryData := make(map[string][]byte)
+
+		for _, v := range input.Values {
+			encodedValue, err := encodeValueForStorage(v)
+			if err != nil {
+				return nil, err
+			}
+
+			isBinary := v.Encoding != nil && *v.Encoding == secret.ValueEncodingBase64
+			if isBinary {
+				binaryData[v.Name] = []byte(encodedValue)
+			} else {
+				data[v.Name] = encodedValue
+			}
+		}
+
+		if len(data) > 0 {
+			cm.Data = data
+		}
+		if len(binaryData) > 0 {
+			cm.BinaryData = binaryData
+		}
 	}
 
 	kubernetes.SetManagedByConsoleLabel(cm)
@@ -140,7 +176,7 @@ func Create(ctx context.Context, teamSlug slug.Slug, environment, name string) (
 		return nil, err
 	}
 
-	created, err := client.Namespace(teamSlug.String()).Create(ctx, &unstructured.Unstructured{Object: u}, v1.CreateOptions{})
+	created, err := client.Namespace(input.TeamSlug.String()).Create(ctx, &unstructured.Unstructured{Object: u}, v1.CreateOptions{})
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
 			return nil, ErrAlreadyExists
@@ -151,16 +187,16 @@ func Create(ctx context.Context, teamSlug slug.Slug, environment, name string) (
 	err = activitylog.Create(ctx, activitylog.CreateInput{
 		Action:          activitylog.ActivityLogEntryActionCreated,
 		Actor:           actor.User,
-		EnvironmentName: &environment,
+		EnvironmentName: &input.EnvironmentName,
 		ResourceType:    activityLogEntryResourceTypeConfig,
-		ResourceName:    name,
-		TeamSlug:        &teamSlug,
+		ResourceName:    input.Name,
+		TeamSlug:        &input.TeamSlug,
 	})
 	if err != nil {
 		fromContext(ctx).log.WithError(err).Errorf("unable to create activity log entry")
 	}
 
-	retVal, ok := toGraphConfig(created, environment)
+	retVal, ok := toGraphConfig(created, input.EnvironmentName)
 	if !ok {
 		return nil, fmt.Errorf("failed to convert config")
 	}
@@ -511,8 +547,10 @@ func RemoveConfigValue(ctx context.Context, teamSlug slug.Slug, environment, con
 }
 
 func Update(ctx context.Context, input UpdateConfigInput) (*Config, error) {
-	if err := model.ValidateUserLabels(input.Labels); err != nil {
-		return nil, err
+	if input.Labels != nil {
+		if err := model.ValidateUserLabels(input.Labels); err != nil {
+			return nil, err
+		}
 	}
 
 	// Validate values
@@ -548,17 +586,19 @@ func Update(ctx context.Context, input UpdateConfigInput) (*Config, error) {
 	var updatedFields []*ConfigUpdatedActivityLogEntryDataUpdatedField
 
 	// Labels
-	existingLabels := obj.GetLabels()
-	mergedLabels := model.MergeUserLabels(existingLabels, input.Labels)
-	if !maps.Equal(mergedLabels, existingLabels) {
-		patch = append(patch, map[string]any{"op": "replace", "path": "/metadata/labels", "value": mergedLabels})
-		oldValue := model.FormatUserLabels(model.UserLabels(existingLabels))
-		newValue := model.FormatUserLabels(model.UserLabels(mergedLabels))
-		updatedFields = append(updatedFields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
-			Field:    "labels",
-			OldValue: &oldValue,
-			NewValue: &newValue,
-		})
+	if input.Labels != nil {
+		existingLabels := obj.GetLabels()
+		mergedLabels := model.MergeUserLabels(existingLabels, input.Labels)
+		if !maps.Equal(mergedLabels, existingLabels) {
+			patch = append(patch, map[string]any{"op": "replace", "path": "/metadata/labels", "value": mergedLabels})
+			oldValue := model.FormatUserLabels(model.UserLabels(existingLabels))
+			newValue := model.FormatUserLabels(model.UserLabels(mergedLabels))
+			updatedFields = append(updatedFields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
+				Field:    "labels",
+				OldValue: &oldValue,
+				NewValue: &newValue,
+			})
+		}
 	}
 
 	// Values — split into data (plain text) and binaryData (base64) based on encoding

--- a/internal/workload/config/queries.go
+++ b/internal/workload/config/queries.go
@@ -691,15 +691,6 @@ func Update(ctx context.Context, input UpdateConfigInput) (*Config, error) {
 	return retVal, nil
 }
 
-func UpdateLabels(ctx context.Context, teamSlug slug.Slug, environment, name string, labels []*model.ResourceLabel) (*Config, error) {
-	return Update(ctx, UpdateConfigInput{
-		Name:            name,
-		EnvironmentName: environment,
-		TeamSlug:        teamSlug,
-		Labels:          labels,
-	})
-}
-
 func Delete(ctx context.Context, teamSlug slug.Slug, environment, name string) error {
 	w := fromContext(ctx).Watcher()
 	client, err := w.ImpersonatedClient(ctx, environment)

--- a/internal/workload/config/queries.go
+++ b/internal/workload/config/queries.go
@@ -162,7 +162,11 @@ func Create(ctx context.Context, input CreateConfigInput) (*Config, error) {
 
 			isBinary := v.Encoding != nil && *v.Encoding == secret.ValueEncodingBase64
 			if isBinary {
-				binaryData[v.Name] = []byte(encodedValue)
+				decoded, err := base64.StdEncoding.DecodeString(encodedValue)
+				if err != nil {
+					return nil, fmt.Errorf("decoding base64 value for key %q: %w", v.Name, err)
+				}
+				binaryData[v.Name] = decoded
 			} else {
 				data[v.Name] = encodedValue
 			}

--- a/internal/workload/config/queries.go
+++ b/internal/workload/config/queries.go
@@ -123,6 +123,13 @@ func Create(ctx context.Context, input CreateConfigInput) (*Config, error) {
 		return nil, fmt.Errorf("invalid name %q: %s", input.Name, strings.Join(nameErrs, ", "))
 	}
 
+	// Validate labels
+	if input.Labels != nil {
+		if err := model.ValidateUserLabels(input.Labels); err != nil {
+			return nil, err
+		}
+	}
+
 	// Validate values
 	if input.Values != nil {
 		for _, v := range input.Values {
@@ -170,6 +177,12 @@ func Create(ctx context.Context, input CreateConfigInput) (*Config, error) {
 	}
 
 	kubernetes.SetManagedByConsoleLabel(cm)
+
+	// Apply user-defined labels
+	if input.Labels != nil {
+		mergedLabels := model.MergeUserLabels(cm.GetLabels(), input.Labels)
+		cm.SetLabels(mergedLabels)
+	}
 
 	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
 	if err != nil {
@@ -620,13 +633,22 @@ func Update(ctx context.Context, input UpdateConfigInput) (*Config, error) {
 			}
 		}
 
-		patch = append(patch,
-			map[string]any{"op": "replace", "path": "/data", "value": newData},
-			map[string]any{"op": "replace", "path": "/binaryData", "value": newBinaryData},
-		)
-		updatedFields = append(updatedFields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
-			Field: "values",
-		})
+		existingData, _, _ := unstructured.NestedStringMap(obj.Object, "data")
+		existingBinaryData, _, _ := unstructured.NestedStringMap(obj.Object, "binaryData")
+
+		dataChanged := !stringMapEqualAny(existingData, newData)
+		binaryDataChanged := !stringMapEqualAny(existingBinaryData, newBinaryData)
+
+		if dataChanged || binaryDataChanged {
+			// Use "add" instead of "replace" because /data and /binaryData may not exist on the ConfigMap
+			patch = append(patch,
+				map[string]any{"op": "add", "path": "/data", "value": newData},
+				map[string]any{"op": "add", "path": "/binaryData", "value": newBinaryData},
+			)
+			updatedFields = append(updatedFields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
+				Field: "values",
+			})
+		}
 	}
 
 	// Nothing changed — return the current state without writing.
@@ -799,4 +821,22 @@ func mergeAnnotations(existingAnnotations map[string]string, user string, extraA
 		}
 	}
 	return merged
+}
+
+// stringMapEqualAny compares a map[string]string (from Kubernetes) with a map[string]any
+// (built for a JSON Patch). Returns true if they have the same keys and values.
+func stringMapEqualAny(existing map[string]string, new map[string]any) bool {
+	if len(existing) != len(new) {
+		return false
+	}
+	for k, v := range new {
+		ev, ok := existing[k]
+		if !ok {
+			return false
+		}
+		if s, ok := v.(string); !ok || s != ev {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/workload/config/queries.go
+++ b/internal/workload/config/queries.go
@@ -595,11 +595,11 @@ func Update(ctx context.Context, input UpdateConfigInput) (*Config, error) {
 		return nil, ErrUnmanaged
 	}
 
-	actor := authz.ActorFromContext(ctx)
-	mergedAnnotations := mergeAnnotations(obj.GetAnnotations(), actor.User.Identity(), nil)
+	existingConfig, ok := toGraphConfig(obj, input.EnvironmentName)
+	if !ok {
+		return nil, fmt.Errorf("failed to convert config")
+	}
 
-	// Build patch operations
-	var patch []map[string]any
 	var updatedFields []*ConfigUpdatedActivityLogEntryDataUpdatedField
 
 	// Labels
@@ -607,7 +607,7 @@ func Update(ctx context.Context, input UpdateConfigInput) (*Config, error) {
 		existingLabels := obj.GetLabels()
 		mergedLabels := model.MergeUserLabels(existingLabels, input.Labels)
 		if !maps.Equal(mergedLabels, existingLabels) {
-			patch = append(patch, map[string]any{"op": "replace", "path": "/metadata/labels", "value": mergedLabels})
+			obj.SetLabels(mergedLabels)
 			oldValue := model.FormatUserLabels(model.UserLabels(existingLabels))
 			newValue := model.FormatUserLabels(model.UserLabels(mergedLabels))
 			updatedFields = append(updatedFields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
@@ -637,44 +637,30 @@ func Update(ctx context.Context, input UpdateConfigInput) (*Config, error) {
 			}
 		}
 
-		existingData, _, _ := unstructured.NestedStringMap(obj.Object, "data")
-		existingBinaryData, _, _ := unstructured.NestedStringMap(obj.Object, "binaryData")
-
-		dataChanged := !stringMapEqualAny(existingData, newData)
-		binaryDataChanged := !stringMapEqualAny(existingBinaryData, newBinaryData)
-
-		if dataChanged || binaryDataChanged {
-			// Use "add" instead of "replace" because /data and /binaryData may not exist on the ConfigMap
-			patch = append(patch,
-				map[string]any{"op": "add", "path": "/data", "value": newData},
-				map[string]any{"op": "add", "path": "/binaryData", "value": newBinaryData},
-			)
-			updatedFields = append(updatedFields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
-				Field: "values",
-			})
+		if !stringMapEqualAny(existingConfig.Data, newData) || !stringMapEqualAny(existingConfig.BinaryData, newBinaryData) {
+			if err := unstructured.SetNestedStringMap(obj.Object, anyMapToStringMap(newData), "data"); err != nil {
+				return nil, fmt.Errorf("setting data: %w", err)
+			}
+			if err := unstructured.SetNestedStringMap(obj.Object, anyMapToStringMap(newBinaryData), "binaryData"); err != nil {
+				return nil, fmt.Errorf("setting binaryData: %w", err)
+			}
+			updatedFields = append(updatedFields, valuesUpdatedFields(existingConfig, newData, newBinaryData)...)
 		}
 	}
 
 	// Nothing changed — return the current state without writing.
-	if len(patch) == 0 {
-		retVal, ok := toGraphConfig(obj, input.EnvironmentName)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert config")
-		}
-		return retVal, nil
+	if len(updatedFields) == 0 {
+		return existingConfig, nil
 	}
 
-	// Always update annotations when something changed
-	patch = append(patch, map[string]any{"op": "replace", "path": "/metadata/annotations", "value": mergedAnnotations})
+	// Update annotations
+	actor := authz.ActorFromContext(ctx)
+	mergedAnnotations := mergeAnnotations(obj.GetAnnotations(), actor.User.Identity(), nil)
+	obj.SetAnnotations(mergedAnnotations)
 
-	patchBytes, err := json.Marshal(patch)
+	_, err = client.Namespace(input.TeamSlug.String()).Update(ctx, obj, v1.UpdateOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("marshaling patch: %w", err)
-	}
-
-	_, err = client.Namespace(input.TeamSlug.String()).Patch(ctx, input.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("patching config: %w", err)
+		return nil, fmt.Errorf("updating config: %w", err)
 	}
 
 	err = activitylog.Create(ctx, activitylog.CreateInput{
@@ -828,7 +814,7 @@ func mergeAnnotations(existingAnnotations map[string]string, user string, extraA
 }
 
 // stringMapEqualAny compares a map[string]string (from Kubernetes) with a map[string]any
-// (built for a JSON Patch). Returns true if they have the same keys and values.
+// (built for storage). Returns true if they have the same keys and values.
 func stringMapEqualAny(existing map[string]string, new map[string]any) bool {
 	if len(existing) != len(new) {
 		return false
@@ -843,4 +829,70 @@ func stringMapEqualAny(existing map[string]string, new map[string]any) bool {
 		}
 	}
 	return true
+}
+
+// anyMapToStringMap converts a map[string]any (where all values are strings) to map[string]string.
+func anyMapToStringMap(m map[string]any) map[string]string {
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		result[k] = v.(string)
+	}
+	return result
+}
+
+// valuesUpdatedFields computes detailed activity log entries for changed config values,
+// reporting which keys were added, removed, or changed.
+func valuesUpdatedFields(existing *Config, newData, newBinaryData map[string]any) []*ConfigUpdatedActivityLogEntryDataUpdatedField {
+	var fields []*ConfigUpdatedActivityLogEntryDataUpdatedField
+
+	// Combine existing values into a single map for comparison
+	oldValues := make(map[string]string, len(existing.Data)+len(existing.BinaryData))
+	for k, v := range existing.Data {
+		oldValues[k] = v
+	}
+	for k, v := range existing.BinaryData {
+		oldValues[k] = v
+	}
+
+	// Combine new values into a single map
+	newValues := make(map[string]string, len(newData)+len(newBinaryData))
+	for k, v := range newData {
+		newValues[k] = v.(string)
+	}
+	for k, v := range newBinaryData {
+		newValues[k] = v.(string)
+	}
+
+	// Check for added or changed keys
+	for k, nv := range newValues {
+		ov, existed := oldValues[k]
+		if !existed {
+			v := nv
+			fields = append(fields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
+				Field:    k,
+				NewValue: &v,
+			})
+		} else if ov != nv {
+			oldVal := ov
+			newVal := nv
+			fields = append(fields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
+				Field:    k,
+				OldValue: &oldVal,
+				NewValue: &newVal,
+			})
+		}
+	}
+
+	// Check for removed keys
+	for k, ov := range oldValues {
+		if _, exists := newValues[k]; !exists {
+			oldVal := ov
+			fields = append(fields, &ConfigUpdatedActivityLogEntryDataUpdatedField{
+				Field:    k,
+				OldValue: &oldVal,
+			})
+		}
+	}
+
+	return fields
 }


### PR DESCRIPTION
Extend `UpdateConfigInput` with optional `values` and route mutation handling through a new `config.Update` function that updates both labels and values. When `values` is set, it replaces `data`/`binaryData` based on value encoding; when omitted, existing values are preserved.

Also improve patch behavior to only write when fields actually change, while still updating annotations and activity log entries for changed fields.