### PR TITLE
fix(authn): prevent open redirect via strict path validation, set SameSite for cookies

### DIFF
--- a/internal/auth/authn/handler.go
+++ b/internal/auth/authn/handler.go
@@ -56,7 +56,7 @@ type claims struct {
 
 func (h *handler) Login(w http.ResponseWriter, r *http.Request) {
 	redirectURI := r.URL.Query().Get("redirect_uri")
-	if len(redirectURI) > 0 && strings.HasPrefix(redirectURI, "/") {
+	if isValidRedirectPath(redirectURI) {
 		http.SetCookie(w, &http.Cookie{
 			Name:     RedirectURICookie,
 			Value:    redirectURI,
@@ -96,7 +96,9 @@ func (h *handler) Callback(w http.ResponseWriter, r *http.Request) {
 	redirectURIRaw, err := r.Cookie(RedirectURICookie)
 	if err == nil {
 		if redirectPath, err := url.QueryUnescape(redirectURIRaw.Value); err == nil {
-			frontendURL = redirectPath
+			if isValidRedirectPath(redirectPath) {
+				frontendURL = redirectPath
+			}
 		}
 	}
 
@@ -214,4 +216,18 @@ func (h *handler) DeleteCookie(w http.ResponseWriter, name string) {
 		Secure:   true,
 		HttpOnly: true,
 	})
+}
+
+// isValidRedirectPath checks that the value is a relative path-only URL
+// (starts with "/", no scheme, no host, no "//" prefix, no backslashes) to prevent open redirects.
+func isValidRedirectPath(s string) bool {
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	return u.Scheme == "" &&
+		u.Host == "" &&
+		strings.HasPrefix(u.Path, "/") &&
+		!strings.HasPrefix(u.Path, "//") &&
+		!strings.ContainsRune(u.Path, '\\')
 }

--- a/internal/auth/authn/handler.go
+++ b/internal/auth/authn/handler.go
@@ -62,6 +62,7 @@ func (h *handler) Login(w http.ResponseWriter, r *http.Request) {
 			Value:    redirectURI,
 			Path:     "/",
 			Expires:  time.Now().Add(30 * time.Minute),
+			SameSite: http.SameSiteLaxMode,
 			Secure:   true,
 			HttpOnly: true,
 		})
@@ -73,6 +74,7 @@ func (h *handler) Login(w http.ResponseWriter, r *http.Request) {
 		Value:    oauthState,
 		Path:     "/",
 		Expires:  time.Now().Add(30 * time.Minute),
+		SameSite: http.SameSiteLaxMode,
 		Secure:   true,
 		HttpOnly: true,
 	})
@@ -202,6 +204,7 @@ func (h *handler) SetSessionCookie(w http.ResponseWriter, session *session.Sessi
 		Value:    session.ID.String(),
 		Path:     "/",
 		Expires:  session.Expires,
+		SameSite: http.SameSiteLaxMode,
 		Secure:   true,
 		HttpOnly: true,
 	})
@@ -213,6 +216,7 @@ func (h *handler) DeleteCookie(w http.ResponseWriter, name string) {
 		Value:    "",
 		Path:     "/",
 		Expires:  time.Unix(0, 0),
+		SameSite: http.SameSiteLaxMode,
 		Secure:   true,
 		HttpOnly: true,
 	})

--- a/internal/auth/authn/handler_test.go
+++ b/internal/auth/authn/handler_test.go
@@ -1,0 +1,50 @@
+package authn
+
+import "testing"
+
+func TestIsValidRedirectPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		// Valid relative paths
+		{name: "root", input: "/", want: true},
+		{name: "simple path", input: "/dashboard", want: true},
+		{name: "nested path", input: "/teams/my-team", want: true},
+		{name: "path with query", input: "/path?query=value", want: true},
+		{name: "path with query and fragment", input: "/path?query=value#fragment", want: true},
+		{name: "trailing slash", input: "/path/with/trailing/slash/", want: true},
+
+		// Empty or relative
+		{name: "empty string", input: "", want: false},
+		{name: "relative path", input: "relative/path", want: false},
+
+		// Absolute URLs with scheme
+		{name: "https", input: "https://example.com", want: false},
+		{name: "https with path", input: "https://example.com/path", want: false},
+		{name: "http", input: "http://example.com", want: false},
+		{name: "javascript scheme", input: "javascript:alert(1)", want: false},
+		{name: "data scheme", input: "data:text/html,<script>alert(1)</script>", want: false},
+
+		// Protocol-relative and backslash tricks
+		{name: "double slash", input: "//example.com", want: false},
+		{name: "double slash with path", input: "//example.com/path", want: false},
+		{name: "triple slash", input: "///example.com", want: false},
+		{name: "quadruple slash", input: "////example.com", want: false},
+		{name: "slash backslash", input: `/\example.com`, want: false},
+		{name: "slash backslash slash", input: `/\/example.com`, want: false},
+		{name: "slash backslash double", input: `/\/\/example.com`, want: false},
+		{name: "backslash double slash", input: `\/\/example.com`, want: false},
+		{name: "encoded backslash", input: "/%5Cexample.com", want: false},
+		{name: "encoded backslash double", input: "/%5C/example.com", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidRedirectPath(tt.input); got != tt.want {
+				t.Errorf("isValidRedirectPath(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Open redirect fix:** The login flow redirects users to a caller-supplied `redirect_uri` after authentication. The old check only required a leading `/`, which is bypassable (`//evil.com`, `/\evil.com`), letting an attacker redirect authenticated users to a malicious host for phishing.

Live examples:

- https://console.nav.cloud.nais.io/oauth2/login?redirect_uri=//example.com
- https://console.nav.cloud.nais.io/oauth2/login?redirect_uri=/\/\example.com
- https://console.nav.cloud.nais.io/oauth2/login?redirect_uri=/\/example.com

**SameSite=Lax:** Defense-in-depth against CSRF on the auth cookies. Lax (not Strict) is required so the cookies still accompany the top-level redirect back from the identity provider.