### PR TITLE
fix: normalize container image parsing

### DIFF
--- a/internal/vulnerability/fake/fakedata.go
+++ b/internal/vulnerability/fake/fakedata.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"math/rand/v2"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/nais/api/internal/team"
+	"github.com/nais/api/internal/workload"
 	"github.com/nais/api/internal/workload/application"
 	"github.com/nais/api/internal/workload/job"
 	"github.com/nais/v13s/pkg/api/vulnerabilities"
@@ -75,9 +75,9 @@ func createFakeData(ctx context.Context) *fakeData {
 }
 
 func createWorkloadSummary(env, team, workloadType, name, image string, vulnFactor int32) *vulnerabilities.WorkloadSummary {
-	parts := strings.Split(image, ":")
-	imageName := parts[0]
-	imageTag := parts[1]
+	parsedImage := workload.ParseContainerImage(image)
+	imageName := parsedImage.Name
+	imageTag := parsedImage.Tag
 	summary := &vulnerabilities.Summary{
 		Critical:    vulnFactor,
 		High:        vulnFactor * 2,

--- a/internal/workload/application/models.go
+++ b/internal/workload/application/models.go
@@ -286,11 +286,7 @@ func toGraphInstance(pod *corev1.Pod, teamSlug slug.Slug, environmentName string
 }
 
 func (i ApplicationInstance) Image() *workload.ContainerImage {
-	name, tag, _ := strings.Cut(i.ImageString, ":")
-	return &workload.ContainerImage{
-		Name: name,
-		Tag:  tag,
-	}
+	return workload.ParseContainerImage(i.ImageString)
 }
 
 type ApplicationManifest struct {

--- a/internal/workload/instancegroup/models.go
+++ b/internal/workload/instancegroup/models.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/nais/api/internal/graph/ident"
@@ -45,11 +44,7 @@ func (ig InstanceGroup) ID() ident.Ident {
 }
 
 func (ig InstanceGroup) Image() *workload.ContainerImage {
-	name, tag, _ := strings.Cut(ig.ImageString, ":")
-	return &workload.ContainerImage{
-		Name: name,
-		Tag:  tag,
-	}
+	return workload.ParseContainerImage(ig.ImageString)
 }
 
 // InstanceGroupEnvironmentVariable represents an environment variable in an instance group.

--- a/internal/workload/job/models.go
+++ b/internal/workload/job/models.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -177,11 +176,7 @@ func (j *JobRun) CompletionTime() *time.Time {
 }
 
 func (j *JobRun) Image() *workload.ContainerImage {
-	name, tag, _ := strings.Cut(j.spec.Spec.Template.Spec.Containers[0].Image, ":")
-	return &workload.ContainerImage{
-		Name: name,
-		Tag:  tag,
-	}
+	return workload.ParseContainerImage(j.spec.Spec.Template.Spec.Containers[0].Image)
 }
 
 // Duration returns the duration of the job run.

--- a/internal/workload/models.go
+++ b/internal/workload/models.go
@@ -61,11 +61,7 @@ type Base struct {
 }
 
 func (b Base) Image() *ContainerImage {
-	name, tag, _ := strings.Cut(b.ImageString, ":")
-	return &ContainerImage{
-		Name: name,
-		Tag:  tag,
-	}
+	return ParseContainerImage(b.ImageString)
 }
 
 func (b Base) GetName() string                           { return b.Name }
@@ -86,6 +82,14 @@ type ContainerImage struct {
 
 func (ContainerImage) IsNode() {}
 func (c ContainerImage) Ref() string {
+	if c.Tag == "" {
+		return c.Name
+	}
+
+	if !strings.Contains(c.Tag, "@") && strings.Contains(c.Tag, ":") {
+		return c.Name + "@" + c.Tag
+	}
+
 	return c.Name + ":" + c.Tag
 }
 
@@ -94,6 +98,37 @@ func (c ContainerImage) ID() ident.Ident {
 }
 
 func (ContainerImage) IsActivityLogger() {}
+
+func ParseContainerImage(image string) *ContainerImage {
+	name, tag := splitContainerImage(image)
+	return &ContainerImage{
+		Name: name,
+		Tag:  tag,
+	}
+}
+
+func splitContainerImage(image string) (name, tag string) {
+	before, after, ok := strings.Cut(image, "@")
+	if ok {
+		image = before
+		if name, tag = splitContainerImageNameTag(image); tag != "" {
+			return name, tag + "@" + after
+		}
+		return name, after
+	}
+
+	return splitContainerImageNameTag(image)
+}
+
+func splitContainerImageNameTag(image string) (name, tag string) {
+	lastSlash := strings.LastIndex(image, "/")
+	segment := image[lastSlash+1:]
+	if before, after, ok := strings.Cut(segment, ":"); ok {
+		return image[:lastSlash+1] + before, after
+	}
+
+	return image, ""
+}
 
 type WorkloadResources interface {
 	IsWorkloadResources()

--- a/internal/workload/models_test.go
+++ b/internal/workload/models_test.go
@@ -1,0 +1,71 @@
+package workload
+
+import (
+	"context"
+	"testing"
+)
+
+func TestParseContainerImageRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		wantName string
+		wantTag  string
+	}{
+		{
+			name:     "no tag or digest",
+			image:    "registry/repo/app",
+			wantName: "registry/repo/app",
+			wantTag:  "",
+		},
+		{
+			name:     "tag",
+			image:    "registry/repo/app:1.2.3",
+			wantName: "registry/repo/app",
+			wantTag:  "1.2.3",
+		},
+		{
+			name:     "digest only",
+			image:    "registry/repo/app@sha256:abc",
+			wantName: "registry/repo/app",
+			wantTag:  "sha256:abc",
+		},
+		{
+			name:     "tag and digest",
+			image:    "registry/repo/app:1.2.3@sha256:abc",
+			wantName: "registry/repo/app",
+			wantTag:  "1.2.3@sha256:abc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed := ParseContainerImage(tt.image)
+			if parsed.Name != tt.wantName {
+				t.Fatalf("name = %q, want %q", parsed.Name, tt.wantName)
+			}
+
+			if parsed.Tag != tt.wantTag {
+				t.Fatalf("tag = %q, want %q", parsed.Tag, tt.wantTag)
+			}
+
+			if got := parsed.Ref(); got != tt.image {
+				t.Fatalf("ref = %q, want %q", got, tt.image)
+			}
+		})
+	}
+}
+
+func TestContainerImageIdentRoundTrip(t *testing.T) {
+	image := "registry/repo/app@sha256:abc"
+
+	ident := newImageIdent(image)
+	parsed, err := getImageByIdent(context.Background(), ident)
+	if err != nil {
+		t.Fatalf("getImageByIdent returned error: %v", err)
+	}
+
+	if got := parsed.Ref(); got != image {
+		t.Fatalf("ref = %q, want %q", got, image)
+	}
+}

--- a/internal/workload/models_test.go
+++ b/internal/workload/models_test.go
@@ -36,6 +36,24 @@ func TestParseContainerImageRoundTrip(t *testing.T) {
 			wantName: "registry/repo/app",
 			wantTag:  "1.2.3@sha256:abc",
 		},
+		{
+			name:     "registry with port and tag",
+			image:    "registry.com:443/image/name:tag",
+			wantName: "registry.com:443/image/name",
+			wantTag:  "tag",
+		},
+		{
+			name:     "registry with port and digest",
+			image:    "registry.com:443/image/name@sha256:abc",
+			wantName: "registry.com:443/image/name",
+			wantTag:  "sha256:abc",
+		},
+		{
+			name:     "registry with port tag and digest",
+			image:    "registry.com:443/image/name:tag@sha256:abc",
+			wantName: "registry.com:443/image/name",
+			wantTag:  "tag@sha256:abc",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/workload/queries.go
+++ b/internal/workload/queries.go
@@ -2,7 +2,6 @@ package workload
 
 import (
 	"context"
-	"strings"
 
 	"github.com/nais/api/internal/graph/ident"
 	"github.com/nais/api/internal/kubernetes/watcher"
@@ -19,11 +18,7 @@ func getImageByIdent(_ context.Context, id ident.Ident) (*ContainerImage, error)
 		return nil, err
 	}
 
-	name, tag, _ := strings.Cut(name, ":")
-	return &ContainerImage{
-		Name: name,
-		Tag:  tag,
-	}, nil
+	return ParseContainerImage(name), nil
 }
 
 func GetMaskinPortenAuthIntegration(mp *nais_io_v1.Maskinporten) *MaskinportenAuthIntegration {


### PR DESCRIPTION
## What
- centralize container image reference parsing in a shared parser
- fix handling of digest-only and tag+digest refs across workload models
- align fake vulnerability data with the same parser
- add regression tests for image round-trip and ident round-trip behavior

## Why
Several places used naive splitting on `:` which breaks OCI image refs such as:
- `registry/repo/app@sha256:abc`
- `registry/repo/app:1.2.3@sha256:abc`

This could cause app/workload pages to look up the wrong image reference in V13S and fail to show SBOM/vulnerability data correctly.

## Changes
- introduced shared parsing in `internal/workload/models.go`
- updated these call sites to use the shared parser:
  - `internal/workload/application/models.go`
  - `internal/workload/instancegroup/models.go`
  - `internal/workload/job/models.go`
  - `internal/workload/queries.go`
  - `internal/vulnerability/fake/fakedata.go`
- fixed `ContainerImage.Ref()` to correctly reconstruct:
  - `name`
  - `name:tag`
  - `name@digest`
  - `name:tag@digest`

## Tests
- added round-trip tests for:
  - `registry/repo/app`
  - `registry/repo/app:1.2.3`
  - `registry/repo/app@sha256:abc`
  - `registry/repo/app:1.2.3@sha256:abc`
- added a `ContainerImage` ident/ref round-trip test
