### PR TITLE
feat(serviceaccount): remove UID binding, improve error messages

### DIFF
--- a/integration_tests/serviceaccount_workload_bindings.lua
+++ b/integration_tests/serviceaccount_workload_bindings.lua
@@ -139,7 +139,7 @@ Test.gql("Add same workload again returns error", function(t)
 		errors = {
 			{
 				locations = NotNull(),
-				message = Contains("already bound to a service account"),
+				message = Contains("already bound to service account"),
 				path = {
 					"addWorkloadToServiceAccount",
 				},

--- a/integration_tests/serviceaccount_workload_bindings_full.lua
+++ b/integration_tests/serviceaccount_workload_bindings_full.lua
@@ -385,7 +385,7 @@ Test.gql("Add duplicate binding returns error", function(t)
 		errors = {
 			{
 				locations = NotNull(),
-				message = Contains("already bound to a service account"),
+				message = Contains("already bound to service account"),
 				path = {
 					"addWorkloadToServiceAccount",
 				},

--- a/internal/auth/middleware/kubernetes_serviceaccount.go
+++ b/internal/auth/middleware/kubernetes_serviceaccount.go
@@ -9,7 +9,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/lestrrat-go/httprc/v3"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/lestrrat-go/jwx/v3/jwt"
@@ -178,14 +177,12 @@ func (k *k8sSAAuth) handler(next http.Handler) http.Handler {
 			entry.environment,
 			claims.TeamSlug,
 			claims.ServiceAccountName,
-			claims.ServiceAccountUID,
 		)
 		if err != nil {
 			k.log.WithError(err).WithFields(logrus.Fields{
 				"environment": entry.environment,
 				"team":        claims.TeamSlug,
 				"sa_name":     claims.ServiceAccountName,
-				"sa_uid":      claims.ServiceAccountUID,
 			}).Debug("k8s sa auth: lookup binding")
 			next.ServeHTTP(w, r)
 			return
@@ -213,7 +210,6 @@ func getJWTIssuer(token string) (string, bool) {
 type k8sClaims struct {
 	TeamSlug           slug.Slug
 	ServiceAccountName string
-	ServiceAccountUID  uuid.UUID
 }
 
 // extractK8sServiceAccount pulls (namespace, sa-name, sa-uid) out of the standard "kubernetes.io" claim that
@@ -230,7 +226,6 @@ func extractK8sServiceAccount(t string) (*k8sClaims, error) {
 			Namespace      string `json:"namespace"`
 			ServiceAccount struct {
 				Name string `json:"name"`
-				UID  string `json:"uid"`
 			} `json:"serviceaccount"`
 		} `json:"kubernetes.io"`
 	}
@@ -244,18 +239,12 @@ func extractK8sServiceAccount(t string) (*k8sClaims, error) {
 		return nil, fmt.Errorf("unmarshaling kubernetes.io claim: %w", err)
 	}
 
-	if claims.Kubernetes.Namespace == "" || claims.Kubernetes.ServiceAccount.Name == "" || claims.Kubernetes.ServiceAccount.UID == "" {
+	if claims.Kubernetes.Namespace == "" || claims.Kubernetes.ServiceAccount.Name == "" {
 		return nil, fmt.Errorf("missing fields in kubernetes.io claim")
-	}
-
-	uid, err := uuid.Parse(claims.Kubernetes.ServiceAccount.UID)
-	if err != nil {
-		return nil, fmt.Errorf("parsing service account UID as UUID: %w", err)
 	}
 
 	return &k8sClaims{
 		TeamSlug:           slug.Slug(claims.Kubernetes.Namespace),
 		ServiceAccountName: claims.Kubernetes.ServiceAccount.Name,
-		ServiceAccountUID:  uid,
 	}, nil
 }

--- a/internal/database/migrations/0071_service_account_binding_remove_uid.sql
+++ b/internal/database/migrations/0071_service_account_binding_remove_uid.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+ALTER TABLE service_account_workload_bindings
+DROP COLUMN kubernetes_service_account_uid
+;

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -27055,11 +27055,6 @@ type RemoveWorkloadFromServiceAccountPayload {
 """
 A binding between a Nais service account and a Nais workload (application or job). When the workload presents its
 Workload Token to the API, the API will authenticate the request as the bound service account.
-
-The binding is identified at authentication time by the workload's environment, team and name, plus the Workload
-UID once it has been observed (trust on first use). If the UID changes (for instance because the workload has
-been recreated), the binding is considered broken and authentication will fail until the binding is removed and
-re-added.
 """
 type ServiceAccountWorkloadBinding implements Node {
 	"""
@@ -27093,8 +27088,7 @@ type ServiceAccountWorkloadBinding implements Node {
 	workloadName: String!
 
 	"""
-	True if the binding is broken — either the workload no longer exists, or the Workload UID
-	does not match the value pinned to the binding.
+	True if the binding is broken, i.e. when the workload no longer exists.
 	"""
 	isBroken: Boolean!
 

--- a/internal/graph/schema/serviceaccount_workload_bindings.graphqls
+++ b/internal/graph/schema/serviceaccount_workload_bindings.graphqls
@@ -90,11 +90,6 @@ type RemoveWorkloadFromServiceAccountPayload {
 """
 A binding between a Nais service account and a Nais workload (application or job). When the workload presents its
 Workload Token to the API, the API will authenticate the request as the bound service account.
-
-The binding is identified at authentication time by the workload's environment, team and name, plus the Workload
-UID once it has been observed (trust on first use). If the UID changes (for instance because the workload has
-been recreated), the binding is considered broken and authentication will fail until the binding is removed and
-re-added.
 """
 type ServiceAccountWorkloadBinding implements Node {
 	"""
@@ -128,8 +123,7 @@ type ServiceAccountWorkloadBinding implements Node {
 	workloadName: String!
 
 	"""
-	True if the binding is broken — either the workload no longer exists, or the Workload UID
-	does not match the value pinned to the binding.
+	True if the binding is broken, i.e. when the workload no longer exists.
 	"""
 	isBroken: Boolean!
 

--- a/internal/graph/serviceaccount_workload_bindings.resolvers.go
+++ b/internal/graph/serviceaccount_workload_bindings.resolvers.go
@@ -63,10 +63,6 @@ func (r *serviceAccountWorkloadBindingResolver) IsBroken(ctx context.Context, ob
 	if err != nil && !errors.Is(err, &watcher.ErrorNotFound{}) {
 		return false, err
 	}
-	// TODO(thokra): Broken if the workload no longer exists. We can't detect UID mismatch from a stored binding alone — that
-	// only surfaces at authentication time when the actual UID does not match the pinned one. Once such an
-	// authentication has been attempted, future requests will keep failing; surfacing UID mismatch here would
-	// require additional bookkeeping which is out of scope for now.
 	return w == nil, nil
 }
 

--- a/internal/serviceaccount/binding_model.go
+++ b/internal/serviceaccount/binding_model.go
@@ -18,15 +18,14 @@ type (
 // ServiceAccountWorkloadBinding represents a binding between a Nais service account and a Nais workload, allowing
 // the workload to authenticate as the service account using its Kubernetes ServiceAccount token.
 type ServiceAccountWorkloadBinding struct {
-	UUID                        uuid.UUID  `json:"-"`
-	ServiceAccountID            uuid.UUID  `json:"-"`
-	Environment                 string     `json:"environment"`
-	TeamSlug                    slug.Slug  `json:"teamSlug"`
-	WorkloadName                string     `json:"workloadName"`
-	KubernetesServiceAccountUID *uuid.UUID `json:"kubernetesServiceAccountUID,omitempty"`
-	CreatedAt                   time.Time  `json:"createdAt"`
-	UpdatedAt                   time.Time  `json:"updatedAt"`
-	LastUsedAt                  *time.Time `json:"lastUsedAt,omitempty"`
+	UUID             uuid.UUID  `json:"-"`
+	ServiceAccountID uuid.UUID  `json:"-"`
+	Environment      string     `json:"environment"`
+	TeamSlug         slug.Slug  `json:"teamSlug"`
+	WorkloadName     string     `json:"workloadName"`
+	CreatedAt        time.Time  `json:"createdAt"`
+	UpdatedAt        time.Time  `json:"updatedAt"`
+	LastUsedAt       *time.Time `json:"lastUsedAt,omitempty"`
 }
 
 func (ServiceAccountWorkloadBinding) IsNode() {}
@@ -62,14 +61,13 @@ func toGraphServiceAccountWorkloadBinding(b *serviceaccountsql.ServiceAccountWor
 		lastUsed = &b.LastUsedAt.Time
 	}
 	return &ServiceAccountWorkloadBinding{
-		UUID:                        b.ID,
-		ServiceAccountID:            b.ServiceAccountID,
-		Environment:                 b.Environment,
-		TeamSlug:                    b.TeamSlug,
-		WorkloadName:                b.WorkloadName,
-		KubernetesServiceAccountUID: b.KubernetesServiceAccountUid,
-		CreatedAt:                   b.CreatedAt.Time,
-		UpdatedAt:                   b.UpdatedAt.Time,
-		LastUsedAt:                  lastUsed,
+		UUID:             b.ID,
+		ServiceAccountID: b.ServiceAccountID,
+		Environment:      b.Environment,
+		TeamSlug:         b.TeamSlug,
+		WorkloadName:     b.WorkloadName,
+		CreatedAt:        b.CreatedAt.Time,
+		UpdatedAt:        b.UpdatedAt.Time,
+		LastUsedAt:       lastUsed,
 	}
 }

--- a/internal/serviceaccount/binding_queries.go
+++ b/internal/serviceaccount/binding_queries.go
@@ -79,7 +79,11 @@ func AddWorkloadBinding(ctx context.Context, input AddWorkloadToServiceAccountIn
 			return nil, nil, err
 		}
 	} else if existing != nil {
-		return nil, nil, apierror.Errorf("The workload %q in team %q is already bound to a service account.", input.WorkloadName, input.TeamSlug)
+		boundSA, err := Get(ctx, existing.ServiceAccountID)
+		if err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, apierror.Errorf("The workload %q in team %q is already bound to service account %q.", input.WorkloadName, input.TeamSlug, boundSA.Name)
 	}
 
 	var binding *serviceaccountsql.ServiceAccountWorkloadBinding
@@ -183,10 +187,10 @@ type AuthLookupResult struct {
 	Binding        *ServiceAccountWorkloadBinding
 }
 
-// AuthenticateKubernetesServiceAccount looks up a binding by (environment, namespace, k8s sa name) and validates the
-// kubernetes service account UID using trust-on-first-use semantics. On a successful match, last_used_at is updated
-// (subject to throttling).
-func AuthenticateKubernetesServiceAccount(ctx context.Context, environment string, teamSlug slug.Slug, k8sServiceAccountName string, k8sServiceAccountUID uuid.UUID) (*AuthLookupResult, error) {
+// AuthenticateKubernetesServiceAccount looks up a binding by (environment, namespace, k8s serviceaccount name).
+// This assumes that service accounts are unique by this combination, i.e. there cannot be multiple service accounts with the exact same name for a given environment and namespace.
+// We do not track the service account UID, so if a service account is deleted and recreated with the same name, the binding will still be valid.
+func AuthenticateKubernetesServiceAccount(ctx context.Context, environment string, teamSlug slug.Slug, k8sServiceAccountName string) (*AuthLookupResult, error) {
 	q := db(ctx)
 	row, err := q.GetBindingByWorkload(ctx, serviceaccountsql.GetBindingByWorkloadParams{
 		Environment:  environment,
@@ -195,34 +199,6 @@ func AuthenticateKubernetesServiceAccount(ctx context.Context, environment strin
 	})
 	if err != nil {
 		return nil, handleBindingError(err)
-	}
-
-	if row.KubernetesServiceAccountUid == nil {
-		// Trust on first use: atomically pin the UID only if still NULL.
-		rowsAffected, err := q.SetBindingKubernetesUID(ctx, serviceaccountsql.SetBindingKubernetesUIDParams{
-			KubernetesServiceAccountUid: &k8sServiceAccountUID,
-			ID:                          row.ID,
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		if rowsAffected == 0 {
-			// Another request pinned the UID concurrently. Re-read and verify.
-			row, err = q.GetBindingByWorkload(ctx, serviceaccountsql.GetBindingByWorkloadParams{
-				Environment:  environment,
-				TeamSlug:     teamSlug,
-				WorkloadName: k8sServiceAccountName,
-			})
-			if err != nil {
-				return nil, handleBindingError(err)
-			}
-			if row.KubernetesServiceAccountUid == nil || *row.KubernetesServiceAccountUid != k8sServiceAccountUID {
-				return nil, ErrUIDMismatch
-			}
-		}
-	} else if *row.KubernetesServiceAccountUid != k8sServiceAccountUID {
-		return nil, ErrUIDMismatch
 	}
 
 	sa, err := Get(ctx, row.ServiceAccountID)

--- a/internal/serviceaccount/queries/workload_bindings.sql
+++ b/internal/serviceaccount/queries/workload_bindings.sql
@@ -72,15 +72,6 @@ ORDER BY
 	created_at
 ;
 
--- name: SetBindingKubernetesUID :execrows
-UPDATE service_account_workload_bindings
-SET
-	kubernetes_service_account_uid = @kubernetes_service_account_uid
-WHERE
-	id = @id
-	AND kubernetes_service_account_uid IS NULL
-;
-
 -- name: UpdateBindingLastUsedAt :exec
 UPDATE service_account_workload_bindings
 SET

--- a/internal/serviceaccount/serviceaccountsql/models.go
+++ b/internal/serviceaccount/serviceaccountsql/models.go
@@ -38,6 +38,4 @@ type ServiceAccountWorkloadBinding struct {
 	Environment      string
 	TeamSlug         slug.Slug
 	WorkloadName     string
-	// The UID of the Kubernetes ServiceAccount, set on first successful authentication (trust-on-first-use).
-	KubernetesServiceAccountUid *uuid.UUID
 }

--- a/internal/serviceaccount/serviceaccountsql/querier.go
+++ b/internal/serviceaccount/serviceaccountsql/querier.go
@@ -30,7 +30,6 @@ type Querier interface {
 	ListForTeam(ctx context.Context, arg ListForTeamParams) ([]*ListForTeamRow, error)
 	ListTokensForServiceAccount(ctx context.Context, arg ListTokensForServiceAccountParams) ([]*ListTokensForServiceAccountRow, error)
 	RemoveApiKeysFromServiceAccount(ctx context.Context, serviceAccountID uuid.UUID) error
-	SetBindingKubernetesUID(ctx context.Context, arg SetBindingKubernetesUIDParams) (int64, error)
 	Update(ctx context.Context, arg UpdateParams) (*ServiceAccount, error)
 	UpdateBindingLastUsedAt(ctx context.Context, id uuid.UUID) error
 	UpdateToken(ctx context.Context, arg UpdateTokenParams) (*ServiceAccountToken, error)

--- a/internal/serviceaccount/serviceaccountsql/workload_bindings.sql.go
+++ b/internal/serviceaccount/serviceaccountsql/workload_bindings.sql.go
@@ -26,7 +26,7 @@ VALUES
 		$4
 	)
 RETURNING
-	id, created_at, updated_at, last_used_at, service_account_id, environment, team_slug, workload_name, kubernetes_service_account_uid
+	id, created_at, updated_at, last_used_at, service_account_id, environment, team_slug, workload_name
 `
 
 type CreateBindingParams struct {
@@ -53,7 +53,6 @@ func (q *Queries) CreateBinding(ctx context.Context, arg CreateBindingParams) (*
 		&i.Environment,
 		&i.TeamSlug,
 		&i.WorkloadName,
-		&i.KubernetesServiceAccountUid,
 	)
 	return &i, err
 }
@@ -71,7 +70,7 @@ func (q *Queries) DeleteBinding(ctx context.Context, id uuid.UUID) error {
 
 const getBindingByID = `-- name: GetBindingByID :one
 SELECT
-	id, created_at, updated_at, last_used_at, service_account_id, environment, team_slug, workload_name, kubernetes_service_account_uid
+	id, created_at, updated_at, last_used_at, service_account_id, environment, team_slug, workload_name
 FROM
 	service_account_workload_bindings
 WHERE
@@ -90,14 +89,13 @@ func (q *Queries) GetBindingByID(ctx context.Context, id uuid.UUID) (*ServiceAcc
 		&i.Environment,
 		&i.TeamSlug,
 		&i.WorkloadName,
-		&i.KubernetesServiceAccountUid,
 	)
 	return &i, err
 }
 
 const getBindingByWorkload = `-- name: GetBindingByWorkload :one
 SELECT
-	id, created_at, updated_at, last_used_at, service_account_id, environment, team_slug, workload_name, kubernetes_service_account_uid
+	id, created_at, updated_at, last_used_at, service_account_id, environment, team_slug, workload_name
 FROM
 	service_account_workload_bindings
 WHERE
@@ -124,14 +122,13 @@ func (q *Queries) GetBindingByWorkload(ctx context.Context, arg GetBindingByWork
 		&i.Environment,
 		&i.TeamSlug,
 		&i.WorkloadName,
-		&i.KubernetesServiceAccountUid,
 	)
 	return &i, err
 }
 
 const getBindingsByIDs = `-- name: GetBindingsByIDs :many
 SELECT
-	id, created_at, updated_at, last_used_at, service_account_id, environment, team_slug, workload_name, kubernetes_service_account_uid
+	id, created_at, updated_at, last_used_at, service_account_id, environment, team_slug, workload_name
 FROM
 	service_account_workload_bindings
 WHERE
@@ -158,7 +155,6 @@ func (q *Queries) GetBindingsByIDs(ctx context.Context, ids []uuid.UUID) ([]*Ser
 			&i.Environment,
 			&i.TeamSlug,
 			&i.WorkloadName,
-			&i.KubernetesServiceAccountUid,
 		); err != nil {
 			return nil, err
 		}
@@ -172,7 +168,7 @@ func (q *Queries) GetBindingsByIDs(ctx context.Context, ids []uuid.UUID) ([]*Ser
 
 const listBindingsForServiceAccount = `-- name: ListBindingsForServiceAccount :many
 SELECT
-	service_account_workload_bindings.id, service_account_workload_bindings.created_at, service_account_workload_bindings.updated_at, service_account_workload_bindings.last_used_at, service_account_workload_bindings.service_account_id, service_account_workload_bindings.environment, service_account_workload_bindings.team_slug, service_account_workload_bindings.workload_name, service_account_workload_bindings.kubernetes_service_account_uid,
+	service_account_workload_bindings.id, service_account_workload_bindings.created_at, service_account_workload_bindings.updated_at, service_account_workload_bindings.last_used_at, service_account_workload_bindings.service_account_id, service_account_workload_bindings.environment, service_account_workload_bindings.team_slug, service_account_workload_bindings.workload_name,
 	COUNT(*) OVER () AS total_count
 FROM
 	service_account_workload_bindings
@@ -217,7 +213,6 @@ func (q *Queries) ListBindingsForServiceAccount(ctx context.Context, arg ListBin
 			&i.ServiceAccountWorkloadBinding.Environment,
 			&i.ServiceAccountWorkloadBinding.TeamSlug,
 			&i.ServiceAccountWorkloadBinding.WorkloadName,
-			&i.ServiceAccountWorkloadBinding.KubernetesServiceAccountUid,
 			&i.TotalCount,
 		); err != nil {
 			return nil, err
@@ -228,28 +223,6 @@ func (q *Queries) ListBindingsForServiceAccount(ctx context.Context, arg ListBin
 		return nil, err
 	}
 	return items, nil
-}
-
-const setBindingKubernetesUID = `-- name: SetBindingKubernetesUID :execrows
-UPDATE service_account_workload_bindings
-SET
-	kubernetes_service_account_uid = $1
-WHERE
-	id = $2
-	AND kubernetes_service_account_uid IS NULL
-`
-
-type SetBindingKubernetesUIDParams struct {
-	KubernetesServiceAccountUid *uuid.UUID
-	ID                          uuid.UUID
-}
-
-func (q *Queries) SetBindingKubernetesUID(ctx context.Context, arg SetBindingKubernetesUIDParams) (int64, error) {
-	result, err := q.db.Exec(ctx, setBindingKubernetesUID, arg.KubernetesServiceAccountUid, arg.ID)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
 }
 
 const updateBindingLastUsedAt = `-- name: UpdateBindingLastUsedAt :exec


### PR DESCRIPTION
We drop tracking Kubernetes ServiceAccount UIDs for workload bindings. We don't have a threat model to justify its usage. 

- This does assume that a Kubernetes ServiceAccount is unique per combination of (cluster, namespace, name).
- If an actor can delete and re-create a workload to assume the identity of a previously bound workload, they can also just modify and replace the existing workload's image with malicious code as they wish.
- Tracking the UID results in more churn for our end-users in cases where they do have legitimate reasons for deleting and re-creating their workloads.

Also return a clearer error message specifying which service account a workload was already bound to if attempting to bind a workload to multiple service accounts.