### PR TITLE
fix: allow vulnerability check to fail temporarily due to GO-2026-5662

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,9 @@ jobs:
           restore-keys: test
       - run: helm lint --strict ./charts/*
       - run: mise run check:staticcheck
-      - run: mise run check:vulncheck
+      - name: Vulnerability check (govulncheck) # Temporary allow-fail due to GO-2026-5662
+        run: mise run check:vulncheck
+        continue-on-error: true
       - name: Check code format and run code generators
         run: |
           mise run fmt ::: generate


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow by allowing the vulnerability check step to fail without causing the whole workflow to fail. This is a temporary measure due to a known issue (GO-2026-5662).

- CI workflow update:
  * Modified the `Vulnerability check (govulncheck)` step in `.github/workflows/main.yaml` to use `continue-on-error: true`, allowing this step to fail without failing the workflow.