### PR TITLE
fix: update OpenTelemetry semconv version to v1.41.0

### DIFF
--- a/internal/cmd/api/http.go
+++ b/internal/cmd/api/http.go
@@ -68,7 +68,7 @@ import (
 	"github.com/rs/cors"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 )

--- a/internal/cmd/api/metrics.go
+++ b/internal/cmd/api/metrics.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 )
 
 func newResource() (*resource.Resource, error) {

--- a/internal/graph/pubsub.go
+++ b/internal/graph/pubsub.go
@@ -12,7 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.41.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"


### PR DESCRIPTION
This pull request updates the OpenTelemetry semantic conventions dependency across several files to use version `v1.41.0` instead of `v1.40.0`. This ensures consistency and compatibility with the latest semantic conventions in OpenTelemetry.

Dependency updates:

* Updated import of `go.opentelemetry.io/otel/semconv` from `v1.40.0` to `v1.41.0` in `internal/cmd/api/http.go`.
* Updated import of `go.opentelemetry.io/otel/semconv` from `v1.40.0` to `v1.41.0` in `internal/cmd/api/metrics.go`.
* Updated import of `go.opentelemetry.io/otel/semconv` from `v1.40.0` to `v1.41.0` in `internal/graph/pubsub.go`.