### PR TITLE
Inject environment matcher for all Prometheus queries

### DIFF
--- a/internal/thirdparty/promclient/client.go
+++ b/internal/thirdparty/promclient/client.go
@@ -89,12 +89,9 @@ func (c *RealClient) Query(ctx context.Context, environmentName string, query st
 		fn(opt)
 	}
 
-	if environmentName != "" {
-		var err error
-		query, err = injectEnvToQuery(query, environmentName)
-		if err != nil {
-			return nil, err
-		}
+	query, err := injectEnvToQuery(query, environmentName)
+	if err != nil {
+		return nil, err
 	}
 
 	v, warnings, err := client.Query(ctx, query, opt.Time)
@@ -119,6 +116,12 @@ func (c *RealClient) Query(ctx context.Context, environmentName string, query st
 
 func (c *RealClient) QueryRange(ctx context.Context, environment string, query string, promRange promv1.Range) (prom.Value, promv1.Warnings, error) {
 	client := c.mimirMetrics
+
+	query, err := injectEnvToQuery(query, environment)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return client.QueryRange(ctx, query, promRange)
 }
 

--- a/internal/thirdparty/promclient/client_test.go
+++ b/internal/thirdparty/promclient/client_test.go
@@ -1,0 +1,60 @@
+package promclient
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	prom "github.com/prometheus/common/model"
+)
+
+// recordingAPI is a minimal promv1.API stub that records the query string
+// passed to Query/QueryRange so tests can assert on it.
+type recordingAPI struct {
+	promv1.API
+	gotQuery string
+}
+
+func (r *recordingAPI) Query(ctx context.Context, query string, ts time.Time, opts ...promv1.Option) (prom.Value, promv1.Warnings, error) {
+	r.gotQuery = query
+	return prom.Vector{}, nil, nil
+}
+
+func (r *recordingAPI) QueryRange(ctx context.Context, query string, rng promv1.Range, opts ...promv1.Option) (prom.Value, promv1.Warnings, error) {
+	r.gotQuery = query
+	return prom.Matrix{}, nil, nil
+}
+
+func TestRealClient_QueryRange_InjectsEnv(t *testing.T) {
+	api := &recordingAPI{}
+	c := &RealClient{mimirMetrics: api}
+
+	query := `avg(disk_used_percent{service="opensearch-team-name"})`
+	want := `avg(disk_used_percent{k8s_cluster_name="prod-gcp",service="opensearch-team-name"})`
+
+	_, _, err := c.QueryRange(t.Context(), "prod-gcp", query, promv1.Range{})
+	if err != nil {
+		t.Fatalf("QueryRange() failed: %v", err)
+	}
+
+	if api.gotQuery != want {
+		t.Errorf("QueryRange() did not inject environment matcher.\ngot:  %s\nwant: %s", api.gotQuery, want)
+	}
+}
+
+func TestRealClient_QueryRange_NoEnv(t *testing.T) {
+	api := &recordingAPI{}
+	c := &RealClient{mimirMetrics: api}
+
+	query := `avg(disk_used_percent{service="opensearch-team-name"})`
+
+	_, _, err := c.QueryRange(t.Context(), "", query, promv1.Range{})
+	if err != nil {
+		t.Fatalf("QueryRange() failed: %v", err)
+	}
+
+	if api.gotQuery != query {
+		t.Errorf("QueryRange() unexpectedly modified query.\ngot:  %s\nwant: %s", api.gotQuery, query)
+	}
+}

--- a/internal/thirdparty/promclient/env_adder.go
+++ b/internal/thirdparty/promclient/env_adder.go
@@ -6,6 +6,10 @@ import (
 )
 
 func injectEnvToQuery(query, env string) (string, error) {
+	if env == "" {
+		return query, nil
+	}
+
 	p := parser.NewParser(parser.Options{})
 	expr, err := p.ParseExpr(query)
 	if err != nil {


### PR DESCRIPTION
Add unit tests to verify `QueryRange` injects `k8s_cluster_name` when an environment is provided and leaves the query unchanged otherwise.