### PR TITLE
feat(serviceaccount): activity log for service accounts

### DIFF
--- a/integration_tests/serviceaccount_activitylog.lua
+++ b/integration_tests/serviceaccount_activitylog.lua
@@ -1,0 +1,244 @@
+-- Three accounts share the name "shared-name": one per team, plus a tenant-wide one. The activity log is
+-- keyed by resource name, so these tests guard against one account's log leaking into another's.
+local admin = User.new("admin", "admin@adminsen.com", "4332")
+admin:admin(true)
+
+Team.new("team-a", "purpose", "#channel")
+Team.new("team-b", "purpose", "#channel")
+
+Test.gql("Create tenant-wide service account", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query [[
+		mutation {
+			createServiceAccount(
+				input: { name: "shared-name", description: "tenant wide" }
+			) {
+				serviceAccount {
+					id
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			createServiceAccount = {
+				serviceAccount = {
+					id = Save("tenantSaID"),
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Create service account with the same name in team-a", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query [[
+		mutation {
+			createServiceAccount(
+				input: { name: "shared-name", description: "team a", teamSlug: "team-a" }
+			) {
+				serviceAccount {
+					id
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			createServiceAccount = {
+				serviceAccount = {
+					id = Save("teamASaID"),
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Create service account with the same name in team-b", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query [[
+		mutation {
+			createServiceAccount(
+				input: { name: "shared-name", description: "team b", teamSlug: "team-b" }
+			) {
+				serviceAccount {
+					id
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			createServiceAccount = {
+				serviceAccount = {
+					id = Save("teamBSaID"),
+				},
+			},
+		},
+	}
+end)
+
+-- A second entry, so the accounts differ by count as well as by team.
+Test.gql("Update the team-a service account", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query(string.format([[
+		mutation {
+			updateServiceAccount(
+				input: { serviceAccountID: "%s", description: "team a updated" }
+			) {
+				serviceAccount {
+					id
+				}
+			}
+		}
+	]], State.teamASaID))
+
+	t.check {
+		data = {
+			updateServiceAccount = {
+				serviceAccount = {
+					id = NotNull(),
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Team-scoped account only sees its own entries", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query(string.format([[
+		query {
+			serviceAccount(id: "%s") {
+				activityLog(first: 10) {
+					nodes {
+						teamSlug
+						resourceName
+						resourceType
+					}
+					pageInfo {
+						totalCount
+					}
+				}
+			}
+		}
+	]], State.teamASaID))
+
+	t.check {
+		data = {
+			serviceAccount = {
+				activityLog = {
+					nodes = {
+						{
+							teamSlug = "team-a",
+							resourceName = "shared-name",
+							resourceType = "SERVICE_ACCOUNT",
+						},
+						{
+							teamSlug = "team-a",
+							resourceName = "shared-name",
+							resourceType = "SERVICE_ACCOUNT",
+						},
+					},
+					pageInfo = {
+						totalCount = 2,
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Other team's account with the same name is unaffected", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query(string.format([[
+		query {
+			serviceAccount(id: "%s") {
+				activityLog(first: 10) {
+					nodes {
+						teamSlug
+					}
+					pageInfo {
+						totalCount
+					}
+				}
+			}
+		}
+	]], State.teamBSaID))
+
+	t.check {
+		data = {
+			serviceAccount = {
+				activityLog = {
+					nodes = {
+						{
+							teamSlug = "team-b",
+						},
+					},
+					pageInfo = {
+						totalCount = 1,
+					},
+				},
+			},
+		},
+	}
+end)
+
+-- The regression that motivated ListForResourceAndTeam. Without it, this returns all four entries.
+Test.gql("Tenant-wide account does not see team-scoped entries", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query(string.format([[
+		query {
+			serviceAccount(id: "%s") {
+				activityLog(first: 10) {
+					nodes {
+						teamSlug
+					}
+					pageInfo {
+						totalCount
+					}
+					facets {
+						activityTypes {
+							activityType
+							count
+						}
+					}
+				}
+			}
+		}
+	]], State.tenantSaID))
+
+	t.check {
+		data = {
+			serviceAccount = {
+				activityLog = {
+					nodes = {
+						{
+							teamSlug = Null,
+						},
+					},
+					pageInfo = {
+						totalCount = 1,
+					},
+					facets = {
+						activityTypes = {
+							{
+								activityType = "SERVICE_ACCOUNT_CREATED",
+								count = 1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)

--- a/integration_tests/serviceaccount_tokens_full.lua
+++ b/integration_tests/serviceaccount_tokens_full.lua
@@ -618,3 +618,134 @@ Test.gql("Create token for deleted service account", function(t)
 		},
 	}
 end)
+
+-- Uses a dedicated service account to isolate these entries from the tests above.
+Test.gql("Create service account for token activity log tests", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query [[
+		mutation {
+			createServiceAccount(
+				input: { name: "token-log-sa", description: "SA for token activity log" }
+			) {
+				serviceAccount {
+					id
+				}
+			}
+		}
+	]]
+
+	t.check {
+		data = {
+			createServiceAccount = {
+				serviceAccount = {
+					id = Save("logSaID"),
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Create a token to rename", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query(string.format([[
+		mutation {
+			createServiceAccountToken(
+				input: {
+					serviceAccountID: "%s"
+					name: "original-token"
+					description: "to be renamed"
+				}
+			) {
+				serviceAccountToken {
+					id
+				}
+			}
+		}
+	]], State.logSaID))
+
+	t.check {
+		data = {
+			createServiceAccountToken = {
+				serviceAccountToken = {
+					id = Save("logTokenID"),
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Rename a token to produce an updated entry", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query(string.format([[
+		mutation {
+			updateServiceAccountToken(
+				input: { serviceAccountTokenID: "%s", name: "renamed-token" }
+			) {
+				serviceAccountToken {
+					id
+				}
+			}
+		}
+	]], State.logTokenID))
+
+	t.check {
+		data = {
+			updateServiceAccountToken = {
+				serviceAccountToken = {
+					id = State.logTokenID,
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Token updated entries name the token that changed", function(t)
+	t.addHeader("x-user-email", admin:email())
+
+	t.query(string.format([[
+		query {
+			serviceAccount(id: "%s") {
+				activityLog(first: 10, filter: { activityTypes: [SERVICE_ACCOUNT_TOKEN_UPDATED] }) {
+					nodes {
+						... on ServiceAccountTokenUpdatedActivityLogEntry {
+							data {
+								tokenName
+								updatedFields {
+									field
+									oldValue
+									newValue
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]], State.logSaID))
+
+	t.check {
+		data = {
+			serviceAccount = {
+				activityLog = {
+					nodes = {
+						{
+							data = {
+								tokenName = "renamed-token",
+								updatedFields = {
+									{
+										field = "name",
+										oldValue = "original-token",
+										newValue = "renamed-token",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)

--- a/integration_tests/workload_serviceaccount.lua
+++ b/integration_tests/workload_serviceaccount.lua
@@ -137,3 +137,202 @@ Test.gql("Query service account through workload interface", function(t)
 		},
 	}
 end)
+
+-- Binding entries resolve the workload by name, so a caller can tell an application from a job.
+Test.gql("Bind service account to a workload that does not exist", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		mutation {
+			addWorkloadToServiceAccount(input: {
+				serviceAccountID: "%s"
+				environment: "dev"
+				teamSlug: "myteam"
+				workloadName: "no-such-workload"
+			}) {
+				binding {
+					isBroken
+				}
+			}
+		}
+	]], State.serviceAccountID))
+
+	t.check {
+		data = {
+			addWorkloadToServiceAccount = {
+				binding = {
+					isBroken = true,
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Binding added entries resolve the bound workload", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		query {
+			serviceAccount(id: "%s") {
+				activityLog(
+					first: 10
+					filter: { activityTypes: [SERVICE_ACCOUNT_WORKLOAD_BINDING_ADDED] }
+				) {
+					nodes {
+						... on ServiceAccountWorkloadBindingAddedActivityLogEntry {
+							data {
+								workloadName
+								workload {
+									__typename
+									name
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]], State.serviceAccountID))
+
+	t.check {
+		data = {
+			serviceAccount = {
+				activityLog = {
+					nodes = {
+						{
+							data = {
+								workloadName = "no-such-workload",
+								workload = Null,
+							},
+						},
+						{
+							data = {
+								workloadName = "job-running",
+								workload = {
+									__typename = "Job",
+									name = "job-running",
+								},
+							},
+						},
+						{
+							data = {
+								workloadName = "app-running",
+								workload = {
+									__typename = "Application",
+									name = "app-running",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("List bindings to find the application binding", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		query {
+			serviceAccount(id: "%s") {
+				workloadBindings(first: 10) {
+					nodes {
+						id
+						workloadName
+					}
+				}
+			}
+		}
+	]], State.serviceAccountID))
+
+	t.check {
+		data = {
+			serviceAccount = {
+				workloadBindings = {
+					nodes = {
+						{
+							id = Save("appBindingID"),
+							workloadName = "app-running",
+						},
+						{
+							id = NotNull(),
+							workloadName = "job-running",
+						},
+						{
+							id = NotNull(),
+							workloadName = "no-such-workload",
+						},
+					},
+				},
+			},
+		},
+	}
+end)
+
+Test.gql("Remove the application binding", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		mutation {
+			removeWorkloadFromServiceAccount(input: { bindingID: "%s" }) {
+				bindingDeleted
+			}
+		}
+	]], State.appBindingID))
+
+	t.check {
+		data = {
+			removeWorkloadFromServiceAccount = {
+				bindingDeleted = true,
+			},
+		},
+	}
+end)
+
+Test.gql("Binding removed entries resolve the workload that is still deployed", function(t)
+	t.addHeader("x-user-email", user:email())
+
+	t.query(string.format([[
+		query {
+			serviceAccount(id: "%s") {
+				activityLog(
+					first: 10
+					filter: { activityTypes: [SERVICE_ACCOUNT_WORKLOAD_BINDING_REMOVED] }
+				) {
+					nodes {
+						... on ServiceAccountWorkloadBindingRemovedActivityLogEntry {
+							data {
+								workloadName
+								workload {
+									__typename
+									name
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	]], State.serviceAccountID))
+
+	t.check {
+		data = {
+			serviceAccount = {
+				activityLog = {
+					nodes = {
+						{
+							data = {
+								workloadName = "app-running",
+								workload = {
+									__typename = "Application",
+									name = "app-running",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+end)

--- a/integration_tests/workload_serviceaccount.lua
+++ b/integration_tests/workload_serviceaccount.lua
@@ -168,7 +168,7 @@ Test.gql("Bind service account to a workload that does not exist", function(t)
 	}
 end)
 
-Test.gql("Binding added entries resolve the bound workload", function(t)
+Test.gql("Binding added entries retain workload details", function(t)
 	t.addHeader("x-user-email", user:email())
 
 	t.query(string.format([[
@@ -180,12 +180,11 @@ Test.gql("Binding added entries resolve the bound workload", function(t)
 				) {
 					nodes {
 						... on ServiceAccountWorkloadBindingAddedActivityLogEntry {
+							environmentName
 							data {
+								teamSlug
 								workloadName
-								workload {
-									__typename
-									name
-								}
+								workloadType
 							}
 						}
 					}
@@ -200,27 +199,27 @@ Test.gql("Binding added entries resolve the bound workload", function(t)
 				activityLog = {
 					nodes = {
 						{
+							environmentName = "dev",
 							data = {
+								teamSlug = "myteam",
 								workloadName = "no-such-workload",
-								workload = Null,
+								workloadType = Null,
 							},
 						},
 						{
+							environmentName = "dev",
 							data = {
+								teamSlug = "myteam",
 								workloadName = "job-running",
-								workload = {
-									__typename = "Job",
-									name = "job-running",
-								},
+								workloadType = "JOB",
 							},
 						},
 						{
+							environmentName = "dev",
 							data = {
+								teamSlug = "myteam",
 								workloadName = "app-running",
-								workload = {
-									__typename = "Application",
-									name = "app-running",
-								},
+								workloadType = "APPLICATION",
 							},
 						},
 					},
@@ -290,7 +289,7 @@ Test.gql("Remove the application binding", function(t)
 	}
 end)
 
-Test.gql("Binding removed entries resolve the workload that is still deployed", function(t)
+Test.gql("Binding removed entries retain workload details", function(t)
 	t.addHeader("x-user-email", user:email())
 
 	t.query(string.format([[
@@ -302,12 +301,11 @@ Test.gql("Binding removed entries resolve the workload that is still deployed", 
 				) {
 					nodes {
 						... on ServiceAccountWorkloadBindingRemovedActivityLogEntry {
+							environmentName
 							data {
+								teamSlug
 								workloadName
-								workload {
-									__typename
-									name
-								}
+								workloadType
 							}
 						}
 					}
@@ -322,12 +320,11 @@ Test.gql("Binding removed entries resolve the workload that is still deployed", 
 				activityLog = {
 					nodes = {
 						{
+							environmentName = "dev",
 							data = {
+								teamSlug = "myteam",
 								workloadName = "app-running",
-								workload = {
-									__typename = "Application",
-									name = "app-running",
-								},
+								workloadType = "APPLICATION",
 							},
 						},
 					},

--- a/internal/activitylog/activitylogsql/activitylog.sql.go
+++ b/internal/activitylog/activitylogsql/activitylog.sql.go
@@ -90,28 +90,33 @@ FROM
 	activity_log_combined_view
 WHERE
 	(
-		$6::TEXT IS NULL
-		OR team_slug = $6
-	)
-	AND (
-		$7::TEXT IS NULL
-		OR resource_type = $7
+		CASE
+		-- When match_null_team is set, a NULL team_slug scopes to tenant-wide resources instead of
+		-- meaning "any team". Keeps facet counts consistent with ListForResourceAndTeam.
+			WHEN $6::BOOLEAN THEN team_slug IS NOT DISTINCT FROM $7::TEXT
+			WHEN $7::TEXT IS NULL THEN TRUE
+			ELSE team_slug = $7
+		END
 	)
 	AND (
 		$8::TEXT IS NULL
-		OR resource_name = $8
+		OR resource_type = $8
 	)
 	AND (
 		$9::TEXT IS NULL
-		OR environment = $9
+		OR resource_name = $9
 	)
 	AND (
-		$10::TIMESTAMPTZ IS NULL
-		OR created_at >= $10::TIMESTAMPTZ
+		$10::TEXT IS NULL
+		OR environment = $10
 	)
 	AND (
 		$11::TIMESTAMPTZ IS NULL
-		OR created_at < $11::TIMESTAMPTZ
+		OR created_at >= $11::TIMESTAMPTZ
+	)
+	AND (
+		$12::TIMESTAMPTZ IS NULL
+		OR created_at < $12::TIMESTAMPTZ
 	)
 GROUP BY
 	resource_type,
@@ -129,6 +134,7 @@ type FacetsForActivityTypesParams struct {
 	FilterEnvironments  []string
 	FilterFrom          pgtype.Timestamptz
 	FilterTo            pgtype.Timestamptz
+	MatchNullTeam       bool
 	TeamSlug            *string
 	ResourceType        *string
 	ResourceName        *string
@@ -152,6 +158,7 @@ func (q *Queries) FacetsForActivityTypes(ctx context.Context, arg FacetsForActiv
 		arg.FilterEnvironments,
 		arg.FilterFrom,
 		arg.FilterTo,
+		arg.MatchNullTeam,
 		arg.TeamSlug,
 		arg.ResourceType,
 		arg.ResourceName,
@@ -323,6 +330,108 @@ func (q *Queries) ListForResource(ctx context.Context, arg ListForResourceParams
 	items := []*ListForResourceRow{}
 	for rows.Next() {
 		var i ListForResourceRow
+		if err := rows.Scan(
+			&i.ActivityLogCombinedView.ID,
+			&i.ActivityLogCombinedView.CreatedAt,
+			&i.ActivityLogCombinedView.Actor,
+			&i.ActivityLogCombinedView.Action,
+			&i.ActivityLogCombinedView.ResourceType,
+			&i.ActivityLogCombinedView.ResourceName,
+			&i.ActivityLogCombinedView.TeamSlug,
+			&i.ActivityLogCombinedView.Data,
+			&i.ActivityLogCombinedView.Environment,
+			&i.TotalCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listForResourceAndTeam = `-- name: ListForResourceAndTeam :many
+SELECT
+	activity_log_combined_view.id, activity_log_combined_view.created_at, activity_log_combined_view.actor, activity_log_combined_view.action, activity_log_combined_view.resource_type, activity_log_combined_view.resource_name, activity_log_combined_view.team_slug, activity_log_combined_view.data, activity_log_combined_view.environment,
+	COUNT(*) OVER () AS total_count
+FROM
+	activity_log_combined_view
+WHERE
+	resource_type = $1
+	AND resource_name = $2
+	AND team_slug IS NOT DISTINCT FROM $3::TEXT
+	AND (
+		$4::TEXT[] IS NULL
+		OR (resource_type || ':' || action) = ANY ($4::TEXT[])
+	)
+	AND (
+		$5::TEXT[] IS NULL
+		OR resource_type = ANY ($5::TEXT[])
+	)
+	AND (
+		$6::TEXT[] IS NULL
+		OR environment = ANY ($6::TEXT[])
+	)
+	AND (
+		$7::TIMESTAMPTZ IS NULL
+		OR created_at >= $7::TIMESTAMPTZ
+	)
+	AND (
+		$8::TIMESTAMPTZ IS NULL
+		OR created_at < $8::TIMESTAMPTZ
+	)
+ORDER BY
+	created_at DESC
+LIMIT
+	$10
+OFFSET
+	$9
+`
+
+type ListForResourceAndTeamParams struct {
+	ResourceType  string
+	ResourceName  string
+	TeamSlug      *string
+	Filter        []string
+	ResourceTypes []string
+	Environments  []string
+	From          pgtype.Timestamptz
+	To            pgtype.Timestamptz
+	Offset        int32
+	Limit         int32
+}
+
+type ListForResourceAndTeamRow struct {
+	ActivityLogCombinedView ActivityLogCombinedView
+	TotalCount              int64
+}
+
+// Scopes entries to a single resource owned by a specific team. Unlike ListForResource, a NULL team_slug
+// matches only entries with a NULL team_slug (tenant-wide resources) rather than every team. This mirrors
+// the "NULLS NOT DISTINCT" unique index on service_accounts (name, team_slug), where the name alone is not
+// unique across the tenant.
+func (q *Queries) ListForResourceAndTeam(ctx context.Context, arg ListForResourceAndTeamParams) ([]*ListForResourceAndTeamRow, error) {
+	rows, err := q.db.Query(ctx, listForResourceAndTeam,
+		arg.ResourceType,
+		arg.ResourceName,
+		arg.TeamSlug,
+		arg.Filter,
+		arg.ResourceTypes,
+		arg.Environments,
+		arg.From,
+		arg.To,
+		arg.Offset,
+		arg.Limit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []*ListForResourceAndTeamRow{}
+	for rows.Next() {
+		var i ListForResourceAndTeamRow
 		if err := rows.Scan(
 			&i.ActivityLogCombinedView.ID,
 			&i.ActivityLogCombinedView.CreatedAt,

--- a/internal/activitylog/activitylogsql/activitylog.sql.go
+++ b/internal/activitylog/activitylogsql/activitylog.sql.go
@@ -91,8 +91,7 @@ FROM
 WHERE
 	(
 		CASE
-		-- When match_null_team is set, a NULL team_slug scopes to tenant-wide resources instead of
-		-- meaning "any team". Keeps facet counts consistent with ListForResourceAndTeam.
+		-- match_null_team keeps facet counts consistent with ListForResourceAndTeam.
 			WHEN $6::BOOLEAN THEN team_slug IS NOT DISTINCT FROM $7::TEXT
 			WHEN $7::TEXT IS NULL THEN TRUE
 			ELSE team_slug = $7
@@ -408,10 +407,8 @@ type ListForResourceAndTeamRow struct {
 	TotalCount              int64
 }
 
-// Scopes entries to a single resource owned by a specific team. Unlike ListForResource, a NULL team_slug
-// matches only entries with a NULL team_slug (tenant-wide resources) rather than every team. This mirrors
-// the "NULLS NOT DISTINCT" unique index on service_accounts (name, team_slug), where the name alone is not
-// unique across the tenant.
+// A NULL team_slug matches tenant-wide resources only, not every team, mirroring the NULLS NOT DISTINCT
+// index on service_accounts (name, team_slug).
 func (q *Queries) ListForResourceAndTeam(ctx context.Context, arg ListForResourceAndTeamParams) ([]*ListForResourceAndTeamRow, error) {
 	rows, err := q.db.Query(ctx, listForResourceAndTeam,
 		arg.ResourceType,

--- a/internal/activitylog/activitylogsql/querier.go
+++ b/internal/activitylog/activitylogsql/querier.go
@@ -14,10 +14,8 @@ type Querier interface {
 	Get(ctx context.Context, id uuid.UUID) (*ActivityLogCombinedView, error)
 	ListByIDs(ctx context.Context, ids []uuid.UUID) ([]*ActivityLogCombinedView, error)
 	ListForResource(ctx context.Context, arg ListForResourceParams) ([]*ListForResourceRow, error)
-	// Scopes entries to a single resource owned by a specific team. Unlike ListForResource, a NULL team_slug
-	// matches only entries with a NULL team_slug (tenant-wide resources) rather than every team. This mirrors
-	// the "NULLS NOT DISTINCT" unique index on service_accounts (name, team_slug), where the name alone is not
-	// unique across the tenant.
+	// A NULL team_slug matches tenant-wide resources only, not every team, mirroring the NULLS NOT DISTINCT
+	// index on service_accounts (name, team_slug).
 	ListForResourceAndTeam(ctx context.Context, arg ListForResourceAndTeamParams) ([]*ListForResourceAndTeamRow, error)
 	ListForResourceTeamAndEnvironment(ctx context.Context, arg ListForResourceTeamAndEnvironmentParams) ([]*ListForResourceTeamAndEnvironmentRow, error)
 	ListForTeam(ctx context.Context, arg ListForTeamParams) ([]*ListForTeamRow, error)

--- a/internal/activitylog/activitylogsql/querier.go
+++ b/internal/activitylog/activitylogsql/querier.go
@@ -14,6 +14,11 @@ type Querier interface {
 	Get(ctx context.Context, id uuid.UUID) (*ActivityLogCombinedView, error)
 	ListByIDs(ctx context.Context, ids []uuid.UUID) ([]*ActivityLogCombinedView, error)
 	ListForResource(ctx context.Context, arg ListForResourceParams) ([]*ListForResourceRow, error)
+	// Scopes entries to a single resource owned by a specific team. Unlike ListForResource, a NULL team_slug
+	// matches only entries with a NULL team_slug (tenant-wide resources) rather than every team. This mirrors
+	// the "NULLS NOT DISTINCT" unique index on service_accounts (name, team_slug), where the name alone is not
+	// unique across the tenant.
+	ListForResourceAndTeam(ctx context.Context, arg ListForResourceAndTeamParams) ([]*ListForResourceAndTeamRow, error)
 	ListForResourceTeamAndEnvironment(ctx context.Context, arg ListForResourceTeamAndEnvironmentParams) ([]*ListForResourceTeamAndEnvironmentRow, error)
 	ListForTeam(ctx context.Context, arg ListForTeamParams) ([]*ListForTeamRow, error)
 	ListForTenant(ctx context.Context, arg ListForTenantParams) ([]*ListForTenantRow, error)

--- a/internal/activitylog/facets.go
+++ b/internal/activitylog/facets.go
@@ -14,6 +14,7 @@ func ComputeFacets(ctx context.Context, scope *ActivityLogScope, filter *Activit
 
 	activityTypeRows, err := q.FacetsForActivityTypes(ctx, activitylogsql.FacetsForActivityTypesParams{
 		TeamSlug:            scopeField(scope, func(s *ActivityLogScope) *string { return (*string)(s.TeamSlug) }),
+		MatchNullTeam:       scope != nil && scope.MatchNullTeam,
 		ResourceType:        scopeField(scope, func(s *ActivityLogScope) *string { return s.ResourceType }),
 		ResourceName:        scopeField(scope, func(s *ActivityLogScope) *string { return s.ResourceName }),
 		EnvironmentName:     scopeField(scope, func(s *ActivityLogScope) *string { return s.EnvironmentName }),

--- a/internal/activitylog/model.go
+++ b/internal/activitylog/model.go
@@ -49,6 +49,10 @@ type ActivityLogScope struct {
 	ResourceType    *string
 	ResourceName    *string
 	EnvironmentName *string
+
+	// MatchNullTeam reads a nil TeamSlug as "no team" rather than "any team". Required where a resource
+	// name is only unique within a team.
+	MatchNullTeam bool
 }
 
 type ActivityLogEntryEdge = pagination.Edge[ActivityLogEntry]

--- a/internal/activitylog/queries.go
+++ b/internal/activitylog/queries.go
@@ -184,6 +184,51 @@ func ListForResource(ctx context.Context, resourceType ActivityLogEntryResourceT
 	}, nil
 }
 
+// ListForResourceAndTeam lists entries for one resource owned by teamSlug. A nil teamSlug means the
+// tenant-wide resource, making it safe for names that are only unique within a team.
+func ListForResourceAndTeam(ctx context.Context, resourceType ActivityLogEntryResourceType, teamSlug *slug.Slug, resourceName string, page *pagination.Pagination, filter *ActivityLogFilter) (*ActivityLogEntryConnection, error) {
+	q := db(ctx)
+
+	ret, err := q.ListForResourceAndTeam(ctx, activitylogsql.ListForResourceAndTeamParams{
+		ResourceType:  string(resourceType),
+		ResourceName:  resourceName,
+		TeamSlug:      (*string)(teamSlug),
+		Offset:        page.Offset(),
+		Limit:         page.Limit(),
+		Filter:        withFilters(filter),
+		ResourceTypes: withResourceTypes(filter),
+		Environments:  withEnvironments(filter),
+		From:          withFrom(filter),
+		To:            withTo(filter),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var total int64
+	if len(ret) > 0 {
+		total = ret[0].TotalCount
+	}
+
+	conn, err := pagination.NewConvertConnectionWithError(ret, page, total, func(from *activitylogsql.ListForResourceAndTeamRow) (ActivityLogEntry, error) {
+		return toGraphActivityLogEntry(&from.ActivityLogCombinedView)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ActivityLogEntryConnection{
+		Connection: *conn,
+		scope: &ActivityLogScope{
+			TeamSlug:      teamSlug,
+			ResourceType:  new(string(resourceType)),
+			ResourceName:  &resourceName,
+			MatchNullTeam: true,
+		},
+		filter: filter,
+	}, nil
+}
+
 func ListForResourceTeamAndEnvironment(ctx context.Context, resourceType ActivityLogEntryResourceType, teamSlug slug.Slug, resourceName, environmentName string, page *pagination.Pagination, filter *ActivityLogFilter) (*ActivityLogEntryConnection, error) {
 	q := db(ctx)
 

--- a/internal/activitylog/queries/activitylog.sql
+++ b/internal/activitylog/queries/activitylog.sql
@@ -106,6 +106,46 @@ OFFSET
 	sqlc.arg('offset')
 ;
 
+-- A NULL team_slug matches tenant-wide resources only, not every team, mirroring the NULLS NOT DISTINCT
+-- index on service_accounts (name, team_slug).
+-- name: ListForResourceAndTeam :many
+SELECT
+	sqlc.embed(activity_log_combined_view),
+	COUNT(*) OVER () AS total_count
+FROM
+	activity_log_combined_view
+WHERE
+	resource_type = @resource_type
+	AND resource_name = @resource_name
+	AND team_slug IS NOT DISTINCT FROM sqlc.narg('team_slug')::TEXT
+	AND (
+		sqlc.narg('filter')::TEXT[] IS NULL
+		OR (resource_type || ':' || action) = ANY (sqlc.narg('filter')::TEXT[])
+	)
+	AND (
+		sqlc.narg('resource_types')::TEXT[] IS NULL
+		OR resource_type = ANY (sqlc.narg('resource_types')::TEXT[])
+	)
+	AND (
+		sqlc.narg('environments')::TEXT[] IS NULL
+		OR environment = ANY (sqlc.narg('environments')::TEXT[])
+	)
+	AND (
+		sqlc.narg('from')::TIMESTAMPTZ IS NULL
+		OR created_at >= sqlc.narg('from')::TIMESTAMPTZ
+	)
+	AND (
+		sqlc.narg('to')::TIMESTAMPTZ IS NULL
+		OR created_at < sqlc.narg('to')::TIMESTAMPTZ
+	)
+ORDER BY
+	created_at DESC
+LIMIT
+	sqlc.arg('limit')
+OFFSET
+	sqlc.arg('offset')
+;
+
 -- name: ListForResourceTeamAndEnvironment :many
 SELECT
 	sqlc.embed(activity_log_combined_view),
@@ -221,8 +261,12 @@ FROM
 	activity_log_combined_view
 WHERE
 	(
-		sqlc.narg('team_slug')::TEXT IS NULL
-		OR team_slug = sqlc.narg('team_slug')
+		CASE
+		-- match_null_team keeps facet counts consistent with ListForResourceAndTeam.
+			WHEN sqlc.arg('match_null_team')::BOOLEAN THEN team_slug IS NOT DISTINCT FROM sqlc.narg('team_slug')::TEXT
+			WHEN sqlc.narg('team_slug')::TEXT IS NULL THEN TRUE
+			ELSE team_slug = sqlc.narg('team_slug')
+		END
 	)
 	AND (
 		sqlc.narg('resource_type')::TEXT IS NULL

--- a/internal/graph/activitylog.resolvers.go
+++ b/internal/graph/activitylog.resolvers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nais/api/internal/persistence/opensearch"
 	"github.com/nais/api/internal/persistence/valkey"
 	"github.com/nais/api/internal/reconciler"
+	"github.com/nais/api/internal/serviceaccount"
 	"github.com/nais/api/internal/team"
 )
 
@@ -50,6 +51,22 @@ func (r *reconcilerResolver) ActivityLog(ctx context.Context, obj *reconciler.Re
 	}
 
 	return activitylog.ListForResource(ctx, reconciler.ActivityLogEntryResourceTypeReconciler, obj.Name, page, filter)
+}
+
+func (r *serviceAccountResolver) ActivityLog(ctx context.Context, obj *serviceaccount.ServiceAccount, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *activitylog.ActivityLogFilter) (*activitylog.ActivityLogEntryConnection, error) {
+	page, err := pagination.ParsePage(first, after, last, before)
+	if err != nil {
+		return nil, err
+	}
+
+	return activitylog.ListForResourceAndTeam(
+		ctx,
+		serviceaccount.ActivityLogEntryResourceTypeServiceAccount,
+		obj.TeamSlug,
+		obj.Name,
+		page,
+		filter,
+	)
 }
 
 func (r *teamResolver) ActivityLog(ctx context.Context, obj *team.Team, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *activitylog.ActivityLogFilter) (*activitylog.ActivityLogEntryConnection, error) {

--- a/internal/graph/gengql/activitylog.generated.go
+++ b/internal/graph/gengql/activitylog.generated.go
@@ -989,6 +989,13 @@ func (ec *executionContext) _ActivityLogger(ctx context.Context, sel ast.Selecti
 			return graphql.Null
 		}
 		return ec._Team(ctx, sel, obj)
+	case serviceaccount.ServiceAccount:
+		return ec._ServiceAccount(ctx, sel, &obj)
+	case *serviceaccount.ServiceAccount:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ServiceAccount(ctx, sel, obj)
 	case secret.Secret:
 		return ec._Secret(ctx, sel, &obj)
 	case *secret.Secret:

--- a/internal/graph/gengql/complexity.go
+++ b/internal/graph/gengql/complexity.go
@@ -172,6 +172,9 @@ func NewComplexityRoot() ComplexityRoot {
 	c.Secret.Workloads = func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) int {
 		return cursorComplexity(first, last) * childComplexity
 	}
+	c.ServiceAccount.ActivityLog = func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *activitylog.ActivityLogFilter) int {
+		return cursorComplexity(first, last) * childComplexity
+	}
 	c.ServiceAccount.Roles = func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) int {
 		return cursorComplexity(first, last) * childComplexity
 	}

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -118,8 +118,6 @@ type ResolverRoot interface {
 	SecretConnection() SecretConnectionResolver
 	ServiceAccount() ServiceAccountResolver
 	ServiceAccountWorkloadBinding() ServiceAccountWorkloadBindingResolver
-	ServiceAccountWorkloadBindingAddedActivityLogEntryData() ServiceAccountWorkloadBindingAddedActivityLogEntryDataResolver
-	ServiceAccountWorkloadBindingRemovedActivityLogEntryData() ServiceAccountWorkloadBindingRemovedActivityLogEntryDataResolver
 	SqlDatabase() SqlDatabaseResolver
 	SqlInstance() SqlInstanceResolver
 	SqlInstanceMetrics() SqlInstanceMetricsResolver
@@ -2485,8 +2483,8 @@ type ComplexityRoot struct {
 
 	ServiceAccountWorkloadBindingAddedActivityLogEntryData struct {
 		TeamSlug     func(childComplexity int) int
-		Workload     func(childComplexity int) int
 		WorkloadName func(childComplexity int) int
+		WorkloadType func(childComplexity int) int
 	}
 
 	ServiceAccountWorkloadBindingConnection struct {
@@ -2514,8 +2512,8 @@ type ComplexityRoot struct {
 
 	ServiceAccountWorkloadBindingRemovedActivityLogEntryData struct {
 		TeamSlug     func(childComplexity int) int
-		Workload     func(childComplexity int) int
 		WorkloadName func(childComplexity int) int
+		WorkloadType func(childComplexity int) int
 	}
 
 	ServiceCostSample struct {
@@ -13951,19 +13949,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.TeamSlug(childComplexity), true
 
-	case "ServiceAccountWorkloadBindingAddedActivityLogEntryData.workload":
-		if e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.Workload == nil {
-			break
-		}
-
-		return e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.Workload(childComplexity), true
-
 	case "ServiceAccountWorkloadBindingAddedActivityLogEntryData.workloadName":
 		if e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.WorkloadName == nil {
 			break
 		}
 
 		return e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.WorkloadName(childComplexity), true
+
+	case "ServiceAccountWorkloadBindingAddedActivityLogEntryData.workloadType":
+		if e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.WorkloadType == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.WorkloadType(childComplexity), true
 
 	case "ServiceAccountWorkloadBindingConnection.edges":
 		if e.ComplexityRoot.ServiceAccountWorkloadBindingConnection.Edges == nil {
@@ -14070,19 +14068,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.TeamSlug(childComplexity), true
 
-	case "ServiceAccountWorkloadBindingRemovedActivityLogEntryData.workload":
-		if e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.Workload == nil {
-			break
-		}
-
-		return e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.Workload(childComplexity), true
-
 	case "ServiceAccountWorkloadBindingRemovedActivityLogEntryData.workloadName":
 		if e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.WorkloadName == nil {
 			break
 		}
 
 		return e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.WorkloadName(childComplexity), true
+
+	case "ServiceAccountWorkloadBindingRemovedActivityLogEntryData.workloadType":
+		if e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.WorkloadType == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.WorkloadType(childComplexity), true
 
 	case "ServiceCostSample.cost":
 		if e.ComplexityRoot.ServiceCostSample.Cost == nil {
@@ -27423,7 +27421,7 @@ type ServiceAccountWorkloadBindingAddedActivityLogEntry implements ActivityLogEn
 	teamSlug: Slug
 
 	"""
-	The environment name that the entry belongs to.
+	The environment the bound workload was deployed in at the time of the binding.
 	"""
 	environmentName: String
 
@@ -27445,9 +27443,9 @@ type ServiceAccountWorkloadBindingAddedActivityLogEntryData {
 	workloadName: String!
 
 	"""
-	The workload the binding refers to. Null if the workload no longer exists, or has not been deployed yet.
+	The type of the workload at the time of the binding. Null if the workload type could not be determined (e.g. workload was not yet deployed).
 	"""
-	workload: Workload
+	workloadType: WorkloadType
 }
 
 type ServiceAccountWorkloadBindingRemovedActivityLogEntry implements ActivityLogEntry & Node {
@@ -27487,7 +27485,7 @@ type ServiceAccountWorkloadBindingRemovedActivityLogEntry implements ActivityLog
 	teamSlug: Slug
 
 	"""
-	The environment name that the entry belongs to.
+	The environment the bound workload was deployed in at the time of removal.
 	"""
 	environmentName: String
 
@@ -27509,9 +27507,9 @@ type ServiceAccountWorkloadBindingRemovedActivityLogEntryData {
 	workloadName: String!
 
 	"""
-	The workload the binding refers to. Null if the workload no longer exists, or has not been deployed yet.
+	The type of the workload at the time of removal. Null if the workload type could not be determined (e.g. workload was not yet deployed).
 	"""
-	workload: Workload
+	workloadType: WorkloadType
 }
 
 extend enum ActivityLogActivityType {
@@ -32669,6 +32667,17 @@ enum EnvironmentWorkloadOrderField {
 }
 
 """
+The type of a workload.
+"""
+enum WorkloadType {
+	"The workload is an application."
+	APPLICATION
+
+	"The workload is a job."
+	JOB
+}
+
+"""
 Encoding of a secret or config value.
 """
 enum ValueEncoding {
@@ -35840,8 +35849,8 @@ func (ec *executionContext) childFields_ServiceAccountWorkloadBindingAddedActivi
 		return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_teamSlug(ctx, field)
 	case "workloadName":
 		return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workloadName(ctx, field)
-	case "workload":
-		return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(ctx, field)
+	case "workloadType":
+		return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workloadType(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type ServiceAccountWorkloadBindingAddedActivityLogEntryData", field.Name)
 }
@@ -35874,8 +35883,8 @@ func (ec *executionContext) childFields_ServiceAccountWorkloadBindingRemovedActi
 		return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_teamSlug(ctx, field)
 	case "workloadName":
 		return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadName(ctx, field)
-	case "workload":
-		return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(ctx, field)
+	case "workloadType":
+		return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadType(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type ServiceAccountWorkloadBindingRemovedActivityLogEntryData", field.Name)
 }

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -118,6 +118,8 @@ type ResolverRoot interface {
 	SecretConnection() SecretConnectionResolver
 	ServiceAccount() ServiceAccountResolver
 	ServiceAccountWorkloadBinding() ServiceAccountWorkloadBindingResolver
+	ServiceAccountWorkloadBindingAddedActivityLogEntryData() ServiceAccountWorkloadBindingAddedActivityLogEntryDataResolver
+	ServiceAccountWorkloadBindingRemovedActivityLogEntryData() ServiceAccountWorkloadBindingRemovedActivityLogEntryDataResolver
 	SqlDatabase() SqlDatabaseResolver
 	SqlInstance() SqlInstanceResolver
 	SqlInstanceMetrics() SqlInstanceMetricsResolver
@@ -2483,6 +2485,7 @@ type ComplexityRoot struct {
 
 	ServiceAccountWorkloadBindingAddedActivityLogEntryData struct {
 		TeamSlug     func(childComplexity int) int
+		Workload     func(childComplexity int) int
 		WorkloadName func(childComplexity int) int
 	}
 
@@ -2511,6 +2514,7 @@ type ComplexityRoot struct {
 
 	ServiceAccountWorkloadBindingRemovedActivityLogEntryData struct {
 		TeamSlug     func(childComplexity int) int
+		Workload     func(childComplexity int) int
 		WorkloadName func(childComplexity int) int
 	}
 
@@ -13947,6 +13951,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.TeamSlug(childComplexity), true
 
+	case "ServiceAccountWorkloadBindingAddedActivityLogEntryData.workload":
+		if e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.Workload == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.Workload(childComplexity), true
+
 	case "ServiceAccountWorkloadBindingAddedActivityLogEntryData.workloadName":
 		if e.ComplexityRoot.ServiceAccountWorkloadBindingAddedActivityLogEntryData.WorkloadName == nil {
 			break
@@ -14058,6 +14069,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.TeamSlug(childComplexity), true
+
+	case "ServiceAccountWorkloadBindingRemovedActivityLogEntryData.workload":
+		if e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.Workload == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.Workload(childComplexity), true
 
 	case "ServiceAccountWorkloadBindingRemovedActivityLogEntryData.workloadName":
 		if e.ComplexityRoot.ServiceAccountWorkloadBindingRemovedActivityLogEntryData.WorkloadName == nil {
@@ -27425,6 +27443,11 @@ type ServiceAccountWorkloadBindingAddedActivityLogEntryData {
 	The name of the workload.
 	"""
 	workloadName: String!
+
+	"""
+	The workload the binding refers to. Null if the workload no longer exists, or has not been deployed yet.
+	"""
+	workload: Workload
 }
 
 type ServiceAccountWorkloadBindingRemovedActivityLogEntry implements ActivityLogEntry & Node {
@@ -27484,6 +27507,11 @@ type ServiceAccountWorkloadBindingRemovedActivityLogEntryData {
 	The name of the workload.
 	"""
 	workloadName: String!
+
+	"""
+	The workload the binding refers to. Null if the workload no longer exists, or has not been deployed yet.
+	"""
+	workload: Workload
 }
 
 extend enum ActivityLogActivityType {
@@ -35812,6 +35840,8 @@ func (ec *executionContext) childFields_ServiceAccountWorkloadBindingAddedActivi
 		return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_teamSlug(ctx, field)
 	case "workloadName":
 		return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workloadName(ctx, field)
+	case "workload":
+		return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type ServiceAccountWorkloadBindingAddedActivityLogEntryData", field.Name)
 }
@@ -35844,6 +35874,8 @@ func (ec *executionContext) childFields_ServiceAccountWorkloadBindingRemovedActi
 		return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_teamSlug(ctx, field)
 	case "workloadName":
 		return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadName(ctx, field)
+	case "workload":
+		return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type ServiceAccountWorkloadBindingRemovedActivityLogEntryData", field.Name)
 }

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -2313,6 +2313,7 @@ type ComplexityRoot struct {
 	}
 
 	ServiceAccount struct {
+		ActivityLog      func(childComplexity int, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *activitylog.ActivityLogFilter) int
 		CreatedAt        func(childComplexity int) int
 		Description      func(childComplexity int) int
 		ID               func(childComplexity int) int
@@ -13155,6 +13156,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.SecretValuesViewedActivityLogEntryData.Reason(childComplexity), true
 
+	case "ServiceAccount.activityLog":
+		if e.ComplexityRoot.ServiceAccount.ActivityLog == nil {
+			break
+		}
+
+		args, err := ec.field_ServiceAccount_activityLog_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.ServiceAccount.ActivityLog(childComplexity, args["first"].(*int), args["after"].(*pagination.Cursor), args["last"].(*int), args["before"].(*pagination.Cursor), args["filter"].(*activitylog.ActivityLogFilter)), true
+
 	case "ServiceAccount.createdAt":
 		if e.ComplexityRoot.ServiceAccount.CreatedAt == nil {
 			break
@@ -19549,6 +19562,38 @@ extend type OpenSearch implements ActivityLogger {
 extend type Valkey implements ActivityLogger {
 	"""
 	Activity log associated with the reconciler.
+	"""
+	activityLog(
+		"""
+		Get the first n items in the connection. This can be used in combination with the after parameter.
+		"""
+		first: Int
+
+		"""
+		Get items after this cursor.
+		"""
+		after: Cursor
+
+		"""
+		Get the last n items in the connection. This can be used in combination with the before parameter.
+		"""
+		last: Int
+
+		"""
+		Get items before this cursor.
+		"""
+		before: Cursor
+
+		"""
+		Filter items.
+		"""
+		filter: ActivityLogFilter
+	): ActivityLogEntryConnection!
+}
+
+extend type ServiceAccount implements ActivityLogger {
+	"""
+	Activity log associated with the service account.
 	"""
 	activityLog(
 		"""
@@ -35594,6 +35639,8 @@ func (ec *executionContext) childFields_ServiceAccount(ctx context.Context, fiel
 		return ec.fieldContext_ServiceAccount_roles(ctx, field)
 	case "tokens":
 		return ec.fieldContext_ServiceAccount_tokens(ctx, field)
+	case "activityLog":
+		return ec.fieldContext_ServiceAccount_activityLog(ctx, field)
 	case "workloadBindings":
 		return ec.fieldContext_ServiceAccount_workloadBindings(ctx, field)
 	}

--- a/internal/graph/gengql/root_.generated.go
+++ b/internal/graph/gengql/root_.generated.go
@@ -2425,6 +2425,7 @@ type ComplexityRoot struct {
 	}
 
 	ServiceAccountTokenUpdatedActivityLogEntryData struct {
+		TokenName     func(childComplexity int) int
 		UpdatedFields func(childComplexity int) int
 	}
 
@@ -13686,6 +13687,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.ServiceAccountTokenUpdatedActivityLogEntry.TeamSlug(childComplexity), true
+
+	case "ServiceAccountTokenUpdatedActivityLogEntryData.tokenName":
+		if e.ComplexityRoot.ServiceAccountTokenUpdatedActivityLogEntryData.TokenName == nil {
+			break
+		}
+
+		return e.ComplexityRoot.ServiceAccountTokenUpdatedActivityLogEntryData.TokenName(childComplexity), true
 
 	case "ServiceAccountTokenUpdatedActivityLogEntryData.updatedFields":
 		if e.ComplexityRoot.ServiceAccountTokenUpdatedActivityLogEntryData.UpdatedFields == nil {
@@ -28389,6 +28397,11 @@ type ServiceAccountTokenUpdatedActivityLogEntry implements ActivityLogEntry & No
 
 type ServiceAccountTokenUpdatedActivityLogEntryData {
 	"""
+	The name of the service account token that was updated. Null if the entry predates this field being recorded.
+	"""
+	tokenName: String
+
+	"""
 	Fields that were updated.
 	"""
 	updatedFields: [ServiceAccountTokenUpdatedActivityLogEntryDataUpdatedField!]!
@@ -35729,6 +35742,8 @@ func (ec *executionContext) childFields_ServiceAccountTokenEdge(ctx context.Cont
 
 func (ec *executionContext) childFields_ServiceAccountTokenUpdatedActivityLogEntryData(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 	switch field.Name {
+	case "tokenName":
+		return ec.fieldContext_ServiceAccountTokenUpdatedActivityLogEntryData_tokenName(ctx, field)
 	case "updatedFields":
 		return ec.fieldContext_ServiceAccountTokenUpdatedActivityLogEntryData_updatedFields(ctx, field)
 	}

--- a/internal/graph/gengql/schema.generated.go
+++ b/internal/graph/gengql/schema.generated.go
@@ -6320,6 +6320,13 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._ServiceAccountCreatedActivityLogEntry(ctx, sel, obj)
+	case serviceaccount.ServiceAccount:
+		return ec._ServiceAccount(ctx, sel, &obj)
+	case *serviceaccount.ServiceAccount:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._ServiceAccount(ctx, sel, obj)
 	case secret.SecretValuesViewedActivityLogEntry:
 		return ec._SecretValuesViewedActivityLogEntry(ctx, sel, &obj)
 	case *secret.SecretValuesViewedActivityLogEntry:
@@ -6801,13 +6808,6 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 			return graphql.Null
 		}
 		return ec._ServiceAccountToken(ctx, sel, obj)
-	case serviceaccount.ServiceAccount:
-		return ec._ServiceAccount(ctx, sel, &obj)
-	case *serviceaccount.ServiceAccount:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._ServiceAccount(ctx, sel, obj)
 	case *authz.Role:
 		if obj == nil {
 			return graphql.Null

--- a/internal/graph/gengql/serviceaccount_workload_bindings.generated.go
+++ b/internal/graph/gengql/serviceaccount_workload_bindings.generated.go
@@ -28,12 +28,6 @@ type ServiceAccountWorkloadBindingResolver interface {
 
 	IsBroken(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBinding) (bool, error)
 }
-type ServiceAccountWorkloadBindingAddedActivityLogEntryDataResolver interface {
-	Workload(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBindingAddedActivityLogEntryData) (workload.Workload, error)
-}
-type ServiceAccountWorkloadBindingRemovedActivityLogEntryDataResolver interface {
-	Workload(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBindingRemovedActivityLogEntryData) (workload.Workload, error)
-}
 
 // endregion ************************** generated!.gotpl **************************
 
@@ -653,36 +647,27 @@ func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingAddedActiv
 	return graphql.NewScalarFieldContext("ServiceAccountWorkloadBindingAddedActivityLogEntryData", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(ctx context.Context, field graphql.CollectedField, obj *serviceaccount.ServiceAccountWorkloadBindingAddedActivityLogEntryData) (ret graphql.Marshaler) {
+func (ec *executionContext) _ServiceAccountWorkloadBindingAddedActivityLogEntryData_workloadType(ctx context.Context, field graphql.CollectedField, obj *serviceaccount.ServiceAccountWorkloadBindingAddedActivityLogEntryData) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(ctx, field)
+			return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workloadType(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.ServiceAccountWorkloadBindingAddedActivityLogEntryData().Workload(ctx, obj)
+			return obj.WorkloadType, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v workload.Workload) graphql.Marshaler {
-			return ec.marshalOWorkload2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐWorkload(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *workload.Type) graphql.Marshaler {
+			return ec.marshalOWorkloadType2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐType(ctx, selections, v)
 		},
 		true,
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ServiceAccountWorkloadBindingAddedActivityLogEntryData",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
-		},
-	}
-	return fc, nil
+func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workloadType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ServiceAccountWorkloadBindingAddedActivityLogEntryData", field, false, false, errors.New("field of type WorkloadType does not have child fields"))
 }
 
 func (ec *executionContext) _ServiceAccountWorkloadBindingConnection_nodes(ctx context.Context, field graphql.CollectedField, obj *pagination.Connection[*serviceaccount.ServiceAccountWorkloadBinding]) (ret graphql.Marshaler) {
@@ -1098,36 +1083,27 @@ func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingRemovedAct
 	return graphql.NewScalarFieldContext("ServiceAccountWorkloadBindingRemovedActivityLogEntryData", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
-func (ec *executionContext) _ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(ctx context.Context, field graphql.CollectedField, obj *serviceaccount.ServiceAccountWorkloadBindingRemovedActivityLogEntryData) (ret graphql.Marshaler) {
+func (ec *executionContext) _ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadType(ctx context.Context, field graphql.CollectedField, obj *serviceaccount.ServiceAccountWorkloadBindingRemovedActivityLogEntryData) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(ctx, field)
+			return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadType(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.ServiceAccountWorkloadBindingRemovedActivityLogEntryData().Workload(ctx, obj)
+			return obj.WorkloadType, nil
 		},
 		nil,
-		func(ctx context.Context, selections ast.SelectionSet, v workload.Workload) graphql.Marshaler {
-			return ec.marshalOWorkload2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐWorkload(ctx, selections, v)
+		func(ctx context.Context, selections ast.SelectionSet, v *workload.Type) graphql.Marshaler {
+			return ec.marshalOWorkloadType2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐType(ctx, selections, v)
 		},
 		true,
 		false,
 	)
 }
-func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ServiceAccountWorkloadBindingRemovedActivityLogEntryData",
-		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
-		},
-	}
-	return fc, nil
+func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ServiceAccountWorkloadBindingRemovedActivityLogEntryData", field, false, false, errors.New("field of type WorkloadType does not have child fields"))
 }
 
 // endregion **************************** field.gotpl *****************************
@@ -1552,46 +1528,15 @@ func (ec *executionContext) _ServiceAccountWorkloadBindingAddedActivityLogEntryD
 		case "teamSlug":
 			out.Values[i] = ec._ServiceAccountWorkloadBindingAddedActivityLogEntryData_teamSlug(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		case "workloadName":
 			out.Values[i] = ec._ServiceAccountWorkloadBindingAddedActivityLogEntryData_workloadName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
-		case "workload":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(ctx, field, obj)
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "workloadType":
+			out.Values[i] = ec._ServiceAccountWorkloadBindingAddedActivityLogEntryData_workloadType(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -1795,46 +1740,15 @@ func (ec *executionContext) _ServiceAccountWorkloadBindingRemovedActivityLogEntr
 		case "teamSlug":
 			out.Values[i] = ec._ServiceAccountWorkloadBindingRemovedActivityLogEntryData_teamSlug(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		case "workloadName":
 			out.Values[i] = ec._ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
-		case "workload":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(ctx, field, obj)
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "workloadType":
+			out.Values[i] = ec._ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadType(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/graph/gengql/serviceaccount_workload_bindings.generated.go
+++ b/internal/graph/gengql/serviceaccount_workload_bindings.generated.go
@@ -28,6 +28,12 @@ type ServiceAccountWorkloadBindingResolver interface {
 
 	IsBroken(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBinding) (bool, error)
 }
+type ServiceAccountWorkloadBindingAddedActivityLogEntryDataResolver interface {
+	Workload(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBindingAddedActivityLogEntryData) (workload.Workload, error)
+}
+type ServiceAccountWorkloadBindingRemovedActivityLogEntryDataResolver interface {
+	Workload(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBindingRemovedActivityLogEntryData) (workload.Workload, error)
+}
 
 // endregion ************************** generated!.gotpl **************************
 
@@ -647,6 +653,38 @@ func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingAddedActiv
 	return graphql.NewScalarFieldContext("ServiceAccountWorkloadBindingAddedActivityLogEntryData", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
+func (ec *executionContext) _ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(ctx context.Context, field graphql.CollectedField, obj *serviceaccount.ServiceAccountWorkloadBindingAddedActivityLogEntryData) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.ServiceAccountWorkloadBindingAddedActivityLogEntryData().Workload(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v workload.Workload) graphql.Marshaler {
+			return ec.marshalOWorkload2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐWorkload(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccountWorkloadBindingAddedActivityLogEntryData",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ServiceAccountWorkloadBindingConnection_nodes(ctx context.Context, field graphql.CollectedField, obj *pagination.Connection[*serviceaccount.ServiceAccountWorkloadBinding]) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1058,6 +1096,38 @@ func (ec *executionContext) _ServiceAccountWorkloadBindingRemovedActivityLogEntr
 }
 func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("ServiceAccountWorkloadBindingRemovedActivityLogEntryData", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(ctx context.Context, field graphql.CollectedField, obj *serviceaccount.ServiceAccountWorkloadBindingRemovedActivityLogEntryData) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.ServiceAccountWorkloadBindingRemovedActivityLogEntryData().Workload(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v workload.Workload) graphql.Marshaler {
+			return ec.marshalOWorkload2githubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐWorkload(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccountWorkloadBindingRemovedActivityLogEntryData",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("FieldContext.Child cannot be called on type INTERFACE")
+		},
+	}
+	return fc, nil
 }
 
 // endregion **************************** field.gotpl *****************************
@@ -1482,13 +1552,46 @@ func (ec *executionContext) _ServiceAccountWorkloadBindingAddedActivityLogEntryD
 		case "teamSlug":
 			out.Values[i] = ec._ServiceAccountWorkloadBindingAddedActivityLogEntryData_teamSlug(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "workloadName":
 			out.Values[i] = ec._ServiceAccountWorkloadBindingAddedActivityLogEntryData_workloadName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "workload":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ServiceAccountWorkloadBindingAddedActivityLogEntryData_workload(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -1692,13 +1795,46 @@ func (ec *executionContext) _ServiceAccountWorkloadBindingRemovedActivityLogEntr
 		case "teamSlug":
 			out.Values[i] = ec._ServiceAccountWorkloadBindingRemovedActivityLogEntryData_teamSlug(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "workloadName":
 			out.Values[i] = ec._ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workloadName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "workload":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ServiceAccountWorkloadBindingRemovedActivityLogEntryData_workload(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/graph/gengql/serviceaccounts.generated.go
+++ b/internal/graph/gengql/serviceaccounts.generated.go
@@ -2815,6 +2815,29 @@ func (ec *executionContext) fieldContext_ServiceAccountTokenUpdatedActivityLogEn
 	return fc, nil
 }
 
+func (ec *executionContext) _ServiceAccountTokenUpdatedActivityLogEntryData_tokenName(ctx context.Context, field graphql.CollectedField, obj *serviceaccount.ServiceAccountTokenUpdatedActivityLogEntryData) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ServiceAccountTokenUpdatedActivityLogEntryData_tokenName(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.TokenName, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_ServiceAccountTokenUpdatedActivityLogEntryData_tokenName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("ServiceAccountTokenUpdatedActivityLogEntryData", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
 func (ec *executionContext) _ServiceAccountTokenUpdatedActivityLogEntryData_updatedFields(ctx context.Context, field graphql.CollectedField, obj *serviceaccount.ServiceAccountTokenUpdatedActivityLogEntryData) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -5059,6 +5082,8 @@ func (ec *executionContext) _ServiceAccountTokenUpdatedActivityLogEntryData(ctx 
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("ServiceAccountTokenUpdatedActivityLogEntryData")
+		case "tokenName":
+			out.Values[i] = ec._ServiceAccountTokenUpdatedActivityLogEntryData_tokenName(ctx, field, obj)
 		case "updatedFields":
 			out.Values[i] = ec._ServiceAccountTokenUpdatedActivityLogEntryData_updatedFields(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/internal/graph/gengql/serviceaccounts.generated.go
+++ b/internal/graph/gengql/serviceaccounts.generated.go
@@ -29,12 +29,59 @@ type ServiceAccountResolver interface {
 	Team(ctx context.Context, obj *serviceaccount.ServiceAccount) (*team.Team, error)
 	Roles(ctx context.Context, obj *serviceaccount.ServiceAccount, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) (*pagination.Connection[*authz.Role], error)
 	Tokens(ctx context.Context, obj *serviceaccount.ServiceAccount, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) (*pagination.Connection[*serviceaccount.ServiceAccountToken], error)
+	ActivityLog(ctx context.Context, obj *serviceaccount.ServiceAccount, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor, filter *activitylog.ActivityLogFilter) (*activitylog.ActivityLogEntryConnection, error)
 	WorkloadBindings(ctx context.Context, obj *serviceaccount.ServiceAccount, first *int, after *pagination.Cursor, last *int, before *pagination.Cursor) (*pagination.Connection[*serviceaccount.ServiceAccountWorkloadBinding], error)
 }
 
 // endregion ************************** generated!.gotpl **************************
 
 // region    ***************************** args.gotpl *****************************
+
+func (ec *executionContext) field_ServiceAccount_activityLog_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "first",
+		func(ctx context.Context, v any) (*int, error) {
+			return ec.unmarshalOInt2ᚖint(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["first"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "after",
+		func(ctx context.Context, v any) (*pagination.Cursor, error) {
+			return ec.unmarshalOCursor2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋgraphᚋpaginationᚐCursor(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["after"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "last",
+		func(ctx context.Context, v any) (*int, error) {
+			return ec.unmarshalOInt2ᚖint(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["last"] = arg2
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "before",
+		func(ctx context.Context, v any) (*pagination.Cursor, error) {
+			return ec.unmarshalOCursor2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋgraphᚋpaginationᚐCursor(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["before"] = arg3
+	arg4, err := graphql.ProcessArgField(ctx, rawArgs, "filter",
+		func(ctx context.Context, v any) (*activitylog.ActivityLogFilter, error) {
+			return ec.unmarshalOActivityLogFilter2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐActivityLogFilter(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["filter"] = arg4
+	return args, nil
+}
 
 func (ec *executionContext) field_ServiceAccount_roles_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
@@ -1149,6 +1196,50 @@ func (ec *executionContext) fieldContext_ServiceAccount_tokens(ctx context.Conte
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_ServiceAccount_tokens_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ServiceAccount_activityLog(ctx context.Context, field graphql.CollectedField, obj *serviceaccount.ServiceAccount) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_ServiceAccount_activityLog(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.ServiceAccount().ActivityLog(ctx, obj, fc.Args["first"].(*int), fc.Args["after"].(*pagination.Cursor), fc.Args["last"].(*int), fc.Args["before"].(*pagination.Cursor), fc.Args["filter"].(*activitylog.ActivityLogFilter))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *activitylog.ActivityLogEntryConnection) graphql.Marshaler {
+			return ec.marshalNActivityLogEntryConnection2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋactivitylogᚐActivityLogEntryConnection(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_ServiceAccount_activityLog(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ServiceAccount",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_ActivityLogEntryConnection(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_ServiceAccount_activityLog_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -4006,7 +4097,7 @@ func (ec *executionContext) _RoleRevokedFromServiceAccountActivityLogEntryData(c
 	return out
 }
 
-var serviceAccountImplementors = []string{"ServiceAccount", "Node", "AuthenticatedUser"}
+var serviceAccountImplementors = []string{"ServiceAccount", "Node", "ActivityLogger", "AuthenticatedUser"}
 
 func (ec *executionContext) _ServiceAccount(ctx context.Context, sel ast.SelectionSet, obj *serviceaccount.ServiceAccount) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, serviceAccountImplementors)
@@ -4154,6 +4245,42 @@ func (ec *executionContext) _ServiceAccount(ctx context.Context, sel ast.Selecti
 					}
 				}()
 				res = ec._ServiceAccount_tokens(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "activityLog":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ServiceAccount_activityLog(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/graph/gengql/users.generated.go
+++ b/internal/graph/gengql/users.generated.go
@@ -480,16 +480,16 @@ func (ec *executionContext) _AuthenticatedUser(ctx context.Context, sel ast.Sele
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case *user.User:
-		if obj == nil {
-			return graphql.Null
-		}
-		return ec._User(ctx, sel, obj)
 	case *serviceaccount.ServiceAccount:
 		if obj == nil {
 			return graphql.Null
 		}
 		return ec._ServiceAccount(ctx, sel, obj)
+	case *user.User:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._User(ctx, sel, obj)
 	default:
 		if typedObj, ok := obj.(graphql.Marshaler); ok {
 			return typedObj

--- a/internal/graph/gengql/workloads.generated.go
+++ b/internal/graph/gengql/workloads.generated.go
@@ -1796,4 +1796,20 @@ func (ec *executionContext) unmarshalOWorkloadOrder2ᚖgithubᚗcomᚋnaisᚋapi
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) unmarshalOWorkloadType2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐType(ctx context.Context, v any) (*workload.Type, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var res = new(workload.Type)
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOWorkloadType2ᚖgithubᚗcomᚋnaisᚋapiᚋinternalᚋworkloadᚐType(ctx context.Context, sel ast.SelectionSet, v *workload.Type) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return v
+}
+
 // endregion ***************************** type.gotpl *****************************

--- a/internal/graph/schema/activitylog.graphqls
+++ b/internal/graph/schema/activitylog.graphqls
@@ -190,6 +190,38 @@ extend type Valkey implements ActivityLogger {
 	): ActivityLogEntryConnection!
 }
 
+extend type ServiceAccount implements ActivityLogger {
+	"""
+	Activity log associated with the service account.
+	"""
+	activityLog(
+		"""
+		Get the first n items in the connection. This can be used in combination with the after parameter.
+		"""
+		first: Int
+
+		"""
+		Get items after this cursor.
+		"""
+		after: Cursor
+
+		"""
+		Get the last n items in the connection. This can be used in combination with the before parameter.
+		"""
+		last: Int
+
+		"""
+		Get items before this cursor.
+		"""
+		before: Cursor
+
+		"""
+		Filter items.
+		"""
+		filter: ActivityLogFilter
+	): ActivityLogEntryConnection!
+}
+
 input ActivityLogFilter {
 	"""
 	Only include entries whose activity type matches one of these values.

--- a/internal/graph/schema/serviceaccount_workload_bindings.graphqls
+++ b/internal/graph/schema/serviceaccount_workload_bindings.graphqls
@@ -205,7 +205,7 @@ type ServiceAccountWorkloadBindingAddedActivityLogEntry implements ActivityLogEn
 	teamSlug: Slug
 
 	"""
-	The environment name that the entry belongs to.
+	The environment the bound workload was deployed in at the time of the binding.
 	"""
 	environmentName: String
 
@@ -227,9 +227,9 @@ type ServiceAccountWorkloadBindingAddedActivityLogEntryData {
 	workloadName: String!
 
 	"""
-	The workload the binding refers to. Null if the workload no longer exists, or has not been deployed yet.
+	The type of the workload at the time of the binding. Null if the workload type could not be determined (e.g. workload was not yet deployed).
 	"""
-	workload: Workload
+	workloadType: WorkloadType
 }
 
 type ServiceAccountWorkloadBindingRemovedActivityLogEntry implements ActivityLogEntry & Node {
@@ -269,7 +269,7 @@ type ServiceAccountWorkloadBindingRemovedActivityLogEntry implements ActivityLog
 	teamSlug: Slug
 
 	"""
-	The environment name that the entry belongs to.
+	The environment the bound workload was deployed in at the time of removal.
 	"""
 	environmentName: String
 
@@ -291,9 +291,9 @@ type ServiceAccountWorkloadBindingRemovedActivityLogEntryData {
 	workloadName: String!
 
 	"""
-	The workload the binding refers to. Null if the workload no longer exists, or has not been deployed yet.
+	The type of the workload at the time of removal. Null if the workload type could not be determined (e.g. workload was not yet deployed).
 	"""
-	workload: Workload
+	workloadType: WorkloadType
 }
 
 extend enum ActivityLogActivityType {

--- a/internal/graph/schema/serviceaccount_workload_bindings.graphqls
+++ b/internal/graph/schema/serviceaccount_workload_bindings.graphqls
@@ -225,6 +225,11 @@ type ServiceAccountWorkloadBindingAddedActivityLogEntryData {
 	The name of the workload.
 	"""
 	workloadName: String!
+
+	"""
+	The workload the binding refers to. Null if the workload no longer exists, or has not been deployed yet.
+	"""
+	workload: Workload
 }
 
 type ServiceAccountWorkloadBindingRemovedActivityLogEntry implements ActivityLogEntry & Node {
@@ -284,6 +289,11 @@ type ServiceAccountWorkloadBindingRemovedActivityLogEntryData {
 	The name of the workload.
 	"""
 	workloadName: String!
+
+	"""
+	The workload the binding refers to. Null if the workload no longer exists, or has not been deployed yet.
+	"""
+	workload: Workload
 }
 
 extend enum ActivityLogActivityType {

--- a/internal/graph/schema/serviceaccounts.graphqls
+++ b/internal/graph/schema/serviceaccounts.graphqls
@@ -902,6 +902,11 @@ type ServiceAccountTokenUpdatedActivityLogEntry implements ActivityLogEntry & No
 
 type ServiceAccountTokenUpdatedActivityLogEntryData {
 	"""
+	The name of the service account token that was updated. Null if the entry predates this field being recorded.
+	"""
+	tokenName: String
+
+	"""
 	Fields that were updated.
 	"""
 	updatedFields: [ServiceAccountTokenUpdatedActivityLogEntryDataUpdatedField!]!

--- a/internal/graph/schema/workloads.graphqls
+++ b/internal/graph/schema/workloads.graphqls
@@ -442,6 +442,17 @@ enum EnvironmentWorkloadOrderField {
 }
 
 """
+The type of a workload.
+"""
+enum WorkloadType {
+	"The workload is an application."
+	APPLICATION
+
+	"The workload is a job."
+	JOB
+}
+
+"""
 Encoding of a secret or config value.
 """
 enum ValueEncoding {

--- a/internal/graph/serviceaccount_workload_bindings.resolvers.go
+++ b/internal/graph/serviceaccount_workload_bindings.resolvers.go
@@ -9,8 +9,6 @@ import (
 	"github.com/nais/api/internal/kubernetes/watcher"
 	"github.com/nais/api/internal/serviceaccount"
 	"github.com/nais/api/internal/workload"
-	"github.com/nais/api/internal/workload/application"
-	"github.com/nais/api/internal/workload/job"
 )
 
 func (r *mutationResolver) AddWorkloadToServiceAccount(ctx context.Context, input serviceaccount.AddWorkloadToServiceAccountInput) (*serviceaccount.AddWorkloadToServiceAccountPayload, error) {
@@ -48,14 +46,7 @@ func (r *serviceAccountWorkloadBindingResolver) ServiceAccount(ctx context.Conte
 }
 
 func (r *serviceAccountWorkloadBindingResolver) Workload(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBinding) (workload.Workload, error) {
-	if app, err := application.Get(ctx, obj.TeamSlug, obj.Environment, obj.WorkloadName); err == nil {
-		return app, nil
-	}
-	if j, err := job.Get(ctx, obj.TeamSlug, obj.Environment, obj.WorkloadName); err == nil {
-		return j, nil
-	}
-	// No matching workload — binding is dangling.
-	return nil, nil
+	return workloadOrNil(ctx, obj.TeamSlug, obj.Environment, obj.WorkloadName), nil
 }
 
 func (r *serviceAccountWorkloadBindingResolver) IsBroken(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBinding) (bool, error) {
@@ -66,8 +57,28 @@ func (r *serviceAccountWorkloadBindingResolver) IsBroken(ctx context.Context, ob
 	return w == nil, nil
 }
 
+func (r *serviceAccountWorkloadBindingAddedActivityLogEntryDataResolver) Workload(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBindingAddedActivityLogEntryData) (workload.Workload, error) {
+	return workloadOrNil(ctx, obj.TeamSlug, obj.Environment, obj.WorkloadName), nil
+}
+
+func (r *serviceAccountWorkloadBindingRemovedActivityLogEntryDataResolver) Workload(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBindingRemovedActivityLogEntryData) (workload.Workload, error) {
+	return workloadOrNil(ctx, obj.TeamSlug, obj.Environment, obj.WorkloadName), nil
+}
+
 func (r *Resolver) ServiceAccountWorkloadBinding() gengql.ServiceAccountWorkloadBindingResolver {
 	return &serviceAccountWorkloadBindingResolver{r}
 }
 
-type serviceAccountWorkloadBindingResolver struct{ *Resolver }
+func (r *Resolver) ServiceAccountWorkloadBindingAddedActivityLogEntryData() gengql.ServiceAccountWorkloadBindingAddedActivityLogEntryDataResolver {
+	return &serviceAccountWorkloadBindingAddedActivityLogEntryDataResolver{r}
+}
+
+func (r *Resolver) ServiceAccountWorkloadBindingRemovedActivityLogEntryData() gengql.ServiceAccountWorkloadBindingRemovedActivityLogEntryDataResolver {
+	return &serviceAccountWorkloadBindingRemovedActivityLogEntryDataResolver{r}
+}
+
+type (
+	serviceAccountWorkloadBindingResolver                            struct{ *Resolver }
+	serviceAccountWorkloadBindingAddedActivityLogEntryDataResolver   struct{ *Resolver }
+	serviceAccountWorkloadBindingRemovedActivityLogEntryDataResolver struct{ *Resolver }
+)

--- a/internal/graph/serviceaccount_workload_bindings.resolvers.go
+++ b/internal/graph/serviceaccount_workload_bindings.resolvers.go
@@ -57,28 +57,8 @@ func (r *serviceAccountWorkloadBindingResolver) IsBroken(ctx context.Context, ob
 	return w == nil, nil
 }
 
-func (r *serviceAccountWorkloadBindingAddedActivityLogEntryDataResolver) Workload(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBindingAddedActivityLogEntryData) (workload.Workload, error) {
-	return workloadOrNil(ctx, obj.TeamSlug, obj.Environment, obj.WorkloadName), nil
-}
-
-func (r *serviceAccountWorkloadBindingRemovedActivityLogEntryDataResolver) Workload(ctx context.Context, obj *serviceaccount.ServiceAccountWorkloadBindingRemovedActivityLogEntryData) (workload.Workload, error) {
-	return workloadOrNil(ctx, obj.TeamSlug, obj.Environment, obj.WorkloadName), nil
-}
-
 func (r *Resolver) ServiceAccountWorkloadBinding() gengql.ServiceAccountWorkloadBindingResolver {
 	return &serviceAccountWorkloadBindingResolver{r}
 }
 
-func (r *Resolver) ServiceAccountWorkloadBindingAddedActivityLogEntryData() gengql.ServiceAccountWorkloadBindingAddedActivityLogEntryDataResolver {
-	return &serviceAccountWorkloadBindingAddedActivityLogEntryDataResolver{r}
-}
-
-func (r *Resolver) ServiceAccountWorkloadBindingRemovedActivityLogEntryData() gengql.ServiceAccountWorkloadBindingRemovedActivityLogEntryDataResolver {
-	return &serviceAccountWorkloadBindingRemovedActivityLogEntryDataResolver{r}
-}
-
-type (
-	serviceAccountWorkloadBindingResolver                            struct{ *Resolver }
-	serviceAccountWorkloadBindingAddedActivityLogEntryDataResolver   struct{ *Resolver }
-	serviceAccountWorkloadBindingRemovedActivityLogEntryDataResolver struct{ *Resolver }
-)
+type serviceAccountWorkloadBindingResolver struct{ *Resolver }

--- a/internal/graph/workloads.go
+++ b/internal/graph/workloads.go
@@ -21,6 +21,17 @@ func tryWorkload(ctx context.Context, teamSlug slug.Slug, environmentName, workl
 	return job.Get(ctx, teamSlug, environmentName, workloadName)
 }
 
+// workloadOrNil resolves a name-based workload reference, returning nil when no workload matches. Unlike
+// [tryWorkload] it never returns a nil pointer wrapped in a non-nil interface, so callers can compare the
+// result against nil. Used for references that are allowed to dangle, such as service account bindings.
+func workloadOrNil(ctx context.Context, teamSlug slug.Slug, environmentName, workloadName string) workload.Workload {
+	w, err := tryWorkload(ctx, teamSlug, environmentName, workloadName)
+	if err != nil {
+		return nil
+	}
+	return w
+}
+
 func getWorkload(ctx context.Context, workloadReference *workload.Reference, teamSlug slug.Slug, environmentName string) (workload.Workload, error) {
 	if workloadReference == nil {
 		return nil, nil

--- a/internal/graph/workloads.go
+++ b/internal/graph/workloads.go
@@ -18,17 +18,18 @@ func tryWorkload(ctx context.Context, teamSlug slug.Slug, environmentName, workl
 		return app, nil
 	}
 
-	return job.Get(ctx, teamSlug, environmentName, workloadName)
+	j, err := job.Get(ctx, teamSlug, environmentName, workloadName)
+	if err != nil {
+		// Returning j here would wrap a nil pointer in a non-nil interface.
+		return nil, err
+	}
+	return j, nil
 }
 
-// workloadOrNil resolves a name-based workload reference, returning nil when no workload matches. Unlike
-// [tryWorkload] it never returns a nil pointer wrapped in a non-nil interface, so callers can compare the
-// result against nil. Used for references that are allowed to dangle, such as service account bindings.
+// workloadOrNil resolves a workload reference that is allowed to dangle, such as a service account
+// binding.
 func workloadOrNil(ctx context.Context, teamSlug slug.Slug, environmentName, workloadName string) workload.Workload {
-	w, err := tryWorkload(ctx, teamSlug, environmentName, workloadName)
-	if err != nil {
-		return nil
-	}
+	w, _ := tryWorkload(ctx, teamSlug, environmentName, workloadName)
 	return w
 }
 

--- a/internal/serviceaccount/activitylog.go
+++ b/internal/serviceaccount/activitylog.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/nais/api/internal/activitylog"
 	"github.com/nais/api/internal/slug"
+	"github.com/nais/api/internal/workload"
 )
 
 const (
@@ -109,9 +110,6 @@ func init() {
 			}, nil
 		case activityLogEntryActionAddServiceAccountWorkloadBinding:
 			data, err := activitylog.TransformData(entry, func(data *ServiceAccountWorkloadBindingAddedActivityLogEntryData) *ServiceAccountWorkloadBindingAddedActivityLogEntryData {
-				if entry.EnvironmentName != nil {
-					data.Environment = *entry.EnvironmentName
-				}
 				return data
 			})
 			if err != nil {
@@ -124,9 +122,6 @@ func init() {
 			}, nil
 		case activityLogEntryActionRemoveServiceAccountWorkloadBinding:
 			data, err := activitylog.TransformData(entry, func(data *ServiceAccountWorkloadBindingRemovedActivityLogEntryData) *ServiceAccountWorkloadBindingRemovedActivityLogEntryData {
-				if entry.EnvironmentName != nil {
-					data.Environment = *entry.EnvironmentName
-				}
 				return data
 			})
 			if err != nil {
@@ -236,11 +231,9 @@ type ServiceAccountWorkloadBindingAddedActivityLogEntry struct {
 }
 
 type ServiceAccountWorkloadBindingAddedActivityLogEntryData struct {
-	TeamSlug     slug.Slug `json:"teamSlug"`
-	WorkloadName string    `json:"workloadName"`
-
-	// Sourced from the entry rather than the payload, so existing entries keep working.
-	Environment string `json:"-"`
+	TeamSlug     slug.Slug      `json:"teamSlug"`
+	WorkloadName string         `json:"workloadName"`
+	WorkloadType *workload.Type `json:"workloadType,omitempty"`
 }
 
 type ServiceAccountWorkloadBindingRemovedActivityLogEntry struct {
@@ -249,9 +242,7 @@ type ServiceAccountWorkloadBindingRemovedActivityLogEntry struct {
 }
 
 type ServiceAccountWorkloadBindingRemovedActivityLogEntryData struct {
-	TeamSlug     slug.Slug `json:"teamSlug"`
-	WorkloadName string    `json:"workloadName"`
-
-	// Sourced from the entry rather than the payload, so existing entries keep working.
-	Environment string `json:"-"`
+	TeamSlug     slug.Slug      `json:"teamSlug"`
+	WorkloadName string         `json:"workloadName"`
+	WorkloadType *workload.Type `json:"workloadType,omitempty"`
 }

--- a/internal/serviceaccount/activitylog.go
+++ b/internal/serviceaccount/activitylog.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	activityLogEntryResourceTypeServiceAccount                activitylog.ActivityLogEntryResourceType = "SERVICE_ACCOUNT"
+	ActivityLogEntryResourceTypeServiceAccount                activitylog.ActivityLogEntryResourceType = "SERVICE_ACCOUNT"
 	activityLogEntryActionAssignServiceAccountRole            activitylog.ActivityLogEntryAction       = "ASSIGN_SERVICE_ACCOUNT_TOKEN_ROLE"
 	activityLogEntryActionRevokeServiceAccountRole            activitylog.ActivityLogEntryAction       = "REVOKE_SERVICE_ACCOUNT_TOKEN_ROLE"
 	activityLogEntryActionCreateServiceAccountToken           activitylog.ActivityLogEntryAction       = "CREATE_SERVICE_ACCOUNT_TOKEN"
@@ -19,7 +19,7 @@ const (
 )
 
 func init() {
-	activitylog.RegisterTransformer(activityLogEntryResourceTypeServiceAccount, func(entry activitylog.GenericActivityLogEntry) (activitylog.ActivityLogEntry, error) {
+	activitylog.RegisterTransformer(ActivityLogEntryResourceTypeServiceAccount, func(entry activitylog.GenericActivityLogEntry) (activitylog.ActivityLogEntry, error) {
 		switch entry.Action {
 		case activitylog.ActivityLogEntryActionCreated:
 			return ServiceAccountCreatedActivityLogEntry{
@@ -136,16 +136,16 @@ func init() {
 		}
 	})
 
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_CREATED", activitylog.ActivityLogEntryActionCreated, activityLogEntryResourceTypeServiceAccount)
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_UPDATED", activitylog.ActivityLogEntryActionUpdated, activityLogEntryResourceTypeServiceAccount)
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_DELETED", activitylog.ActivityLogEntryActionDeleted, activityLogEntryResourceTypeServiceAccount)
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_TOKEN_CREATED", activityLogEntryActionCreateServiceAccountToken, activityLogEntryResourceTypeServiceAccount)
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_TOKEN_UPDATED", activityLogEntryActionUpdateServiceAccountToken, activityLogEntryResourceTypeServiceAccount)
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_TOKEN_DELETED", activityLogEntryActionDeleteServiceAccountToken, activityLogEntryResourceTypeServiceAccount)
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_ROLE_ASSIGNED", activityLogEntryActionAssignServiceAccountRole, activityLogEntryResourceTypeServiceAccount)
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_ROLE_REVOKED", activityLogEntryActionRevokeServiceAccountRole, activityLogEntryResourceTypeServiceAccount)
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_WORKLOAD_BINDING_ADDED", activityLogEntryActionAddServiceAccountWorkloadBinding, activityLogEntryResourceTypeServiceAccount)
-	activitylog.RegisterFilter("SERVICE_ACCOUNT_WORKLOAD_BINDING_REMOVED", activityLogEntryActionRemoveServiceAccountWorkloadBinding, activityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_CREATED", activitylog.ActivityLogEntryActionCreated, ActivityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_UPDATED", activitylog.ActivityLogEntryActionUpdated, ActivityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_DELETED", activitylog.ActivityLogEntryActionDeleted, ActivityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_TOKEN_CREATED", activityLogEntryActionCreateServiceAccountToken, ActivityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_TOKEN_UPDATED", activityLogEntryActionUpdateServiceAccountToken, ActivityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_TOKEN_DELETED", activityLogEntryActionDeleteServiceAccountToken, ActivityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_ROLE_ASSIGNED", activityLogEntryActionAssignServiceAccountRole, ActivityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_ROLE_REVOKED", activityLogEntryActionRevokeServiceAccountRole, ActivityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_WORKLOAD_BINDING_ADDED", activityLogEntryActionAddServiceAccountWorkloadBinding, ActivityLogEntryResourceTypeServiceAccount)
+	activitylog.RegisterFilter("SERVICE_ACCOUNT_WORKLOAD_BINDING_REMOVED", activityLogEntryActionRemoveServiceAccountWorkloadBinding, ActivityLogEntryResourceTypeServiceAccount)
 }
 
 type RoleAssignedToServiceAccountActivityLogEntry struct {

--- a/internal/serviceaccount/activitylog.go
+++ b/internal/serviceaccount/activitylog.go
@@ -109,6 +109,9 @@ func init() {
 			}, nil
 		case activityLogEntryActionAddServiceAccountWorkloadBinding:
 			data, err := activitylog.TransformData(entry, func(data *ServiceAccountWorkloadBindingAddedActivityLogEntryData) *ServiceAccountWorkloadBindingAddedActivityLogEntryData {
+				if entry.EnvironmentName != nil {
+					data.Environment = *entry.EnvironmentName
+				}
 				return data
 			})
 			if err != nil {
@@ -121,6 +124,9 @@ func init() {
 			}, nil
 		case activityLogEntryActionRemoveServiceAccountWorkloadBinding:
 			data, err := activitylog.TransformData(entry, func(data *ServiceAccountWorkloadBindingRemovedActivityLogEntryData) *ServiceAccountWorkloadBindingRemovedActivityLogEntryData {
+				if entry.EnvironmentName != nil {
+					data.Environment = *entry.EnvironmentName
+				}
 				return data
 			})
 			if err != nil {
@@ -232,6 +238,9 @@ type ServiceAccountWorkloadBindingAddedActivityLogEntry struct {
 type ServiceAccountWorkloadBindingAddedActivityLogEntryData struct {
 	TeamSlug     slug.Slug `json:"teamSlug"`
 	WorkloadName string    `json:"workloadName"`
+
+	// Sourced from the entry rather than the payload, so existing entries keep working.
+	Environment string `json:"-"`
 }
 
 type ServiceAccountWorkloadBindingRemovedActivityLogEntry struct {
@@ -242,4 +251,7 @@ type ServiceAccountWorkloadBindingRemovedActivityLogEntry struct {
 type ServiceAccountWorkloadBindingRemovedActivityLogEntryData struct {
 	TeamSlug     slug.Slug `json:"teamSlug"`
 	WorkloadName string    `json:"workloadName"`
+
+	// Sourced from the entry rather than the payload, so existing entries keep working.
+	Environment string `json:"-"`
 }

--- a/internal/serviceaccount/activitylog.go
+++ b/internal/serviceaccount/activitylog.go
@@ -59,7 +59,7 @@ func init() {
 		case activityLogEntryActionUpdateServiceAccountToken:
 			data, err := activitylog.TransformData(entry, func(data *ServiceAccountTokenUpdatedActivityLogEntryData) *ServiceAccountTokenUpdatedActivityLogEntryData {
 				if len(data.UpdatedFields) == 0 {
-					return &ServiceAccountTokenUpdatedActivityLogEntryData{}
+					return &ServiceAccountTokenUpdatedActivityLogEntryData{TokenName: data.TokenName}
 				}
 				return data
 			})
@@ -194,6 +194,8 @@ type ServiceAccountTokenUpdatedActivityLogEntry struct {
 }
 
 type ServiceAccountTokenUpdatedActivityLogEntryData struct {
+	// Nil for entries written before this field existed.
+	TokenName     *string                                                       `json:"tokenName,omitempty"`
 	UpdatedFields []*ServiceAccountTokenUpdatedActivityLogEntryDataUpdatedField `json:"updatedFields"`
 }
 

--- a/internal/serviceaccount/binding_queries.go
+++ b/internal/serviceaccount/binding_queries.go
@@ -12,8 +12,12 @@ import (
 	"github.com/nais/api/internal/graph/apierror"
 	"github.com/nais/api/internal/graph/ident"
 	"github.com/nais/api/internal/graph/pagination"
+	"github.com/nais/api/internal/kubernetes/watcher"
 	"github.com/nais/api/internal/serviceaccount/serviceaccountsql"
 	"github.com/nais/api/internal/slug"
+	"github.com/nais/api/internal/workload"
+	"github.com/nais/api/internal/workload/application"
+	"github.com/nais/api/internal/workload/job"
 )
 
 // throttleLastUsedAt determines how often the last_used_at column may be updated. We avoid a write per
@@ -86,6 +90,11 @@ func AddWorkloadBinding(ctx context.Context, input AddWorkloadToServiceAccountIn
 		return nil, nil, apierror.Errorf("The workload %q in team %q is already bound to service account %q.", input.WorkloadName, input.TeamSlug, boundSA.Name)
 	}
 
+	workloadType, err := resolveWorkloadType(ctx, input.TeamSlug, input.Environment, input.WorkloadName)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	var binding *serviceaccountsql.ServiceAccountWorkloadBinding
 	err = database.Transaction(ctx, func(ctx context.Context) error {
 		var err error
@@ -109,6 +118,7 @@ func AddWorkloadBinding(ctx context.Context, input AddWorkloadToServiceAccountIn
 			Data: &ServiceAccountWorkloadBindingAddedActivityLogEntryData{
 				TeamSlug:     input.TeamSlug,
 				WorkloadName: input.WorkloadName,
+				WorkloadType: workloadType,
 			},
 		})
 	})
@@ -136,6 +146,11 @@ func RemoveWorkloadBinding(ctx context.Context, input RemoveWorkloadFromServiceA
 		return nil, err
 	}
 
+	workloadType, err := resolveWorkloadType(ctx, binding.TeamSlug, binding.Environment, binding.WorkloadName)
+	if err != nil {
+		return nil, err
+	}
+
 	err = database.Transaction(ctx, func(ctx context.Context) error {
 		if err := db(ctx).DeleteBinding(ctx, binding.UUID); err != nil {
 			return err
@@ -152,6 +167,7 @@ func RemoveWorkloadBinding(ctx context.Context, input RemoveWorkloadFromServiceA
 			Data: &ServiceAccountWorkloadBindingRemovedActivityLogEntryData{
 				TeamSlug:     binding.TeamSlug,
 				WorkloadName: binding.WorkloadName,
+				WorkloadType: workloadType,
 			},
 		})
 	})
@@ -216,4 +232,25 @@ func AuthenticateKubernetesServiceAccount(ctx context.Context, environment strin
 		ServiceAccount: sa,
 		Binding:        toGraphServiceAccountWorkloadBinding(row),
 	}, nil
+}
+
+// resolveWorkloadType returns the workload type for the given workload reference, or nil if not found.
+func resolveWorkloadType(ctx context.Context, teamSlug slug.Slug, environment, workloadName string) (*workload.Type, error) {
+	app, err := application.Get(ctx, teamSlug, environment, workloadName)
+	if err != nil && !errors.Is(err, &watcher.ErrorNotFound{}) {
+		return nil, err
+	}
+	if app != nil {
+		t := app.GetType()
+		return &t, nil
+	}
+	j, err := job.Get(ctx, teamSlug, environment, workloadName)
+	if err != nil && !errors.Is(err, &watcher.ErrorNotFound{}) {
+		return nil, err
+	}
+	if j != nil {
+		t := j.GetType()
+		return &t, nil
+	}
+	return nil, nil
 }

--- a/internal/serviceaccount/binding_queries.go
+++ b/internal/serviceaccount/binding_queries.go
@@ -102,7 +102,7 @@ func AddWorkloadBinding(ctx context.Context, input AddWorkloadToServiceAccountIn
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:          activityLogEntryActionAddServiceAccountWorkloadBinding,
 			Actor:           authz.ActorFromContext(ctx).User,
-			ResourceType:    activityLogEntryResourceTypeServiceAccount,
+			ResourceType:    ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName:    sa.Name,
 			TeamSlug:        sa.TeamSlug,
 			EnvironmentName: &input.Environment,
@@ -145,7 +145,7 @@ func RemoveWorkloadBinding(ctx context.Context, input RemoveWorkloadFromServiceA
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:          activityLogEntryActionRemoveServiceAccountWorkloadBinding,
 			Actor:           authz.ActorFromContext(ctx).User,
-			ResourceType:    activityLogEntryResourceTypeServiceAccount,
+			ResourceType:    ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName:    sa.Name,
 			TeamSlug:        sa.TeamSlug,
 			EnvironmentName: &env,

--- a/internal/serviceaccount/model.go
+++ b/internal/serviceaccount/model.go
@@ -29,6 +29,7 @@ type ServiceAccount struct {
 }
 
 func (ServiceAccount) IsNode()                   {}
+func (ServiceAccount) IsActivityLogger()         {}
 func (s *ServiceAccount) GetID() uuid.UUID       { return s.UUID }
 func (s *ServiceAccount) Identity() string       { return s.Name }
 func (s *ServiceAccount) IsServiceAccount() bool { return true }

--- a/internal/serviceaccount/queries.go
+++ b/internal/serviceaccount/queries.go
@@ -290,15 +290,10 @@ func UpdateToken(ctx context.Context, input UpdateServiceAccountTokenInput) (*Se
 			ResourceType: ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName: sa.Name,
 			TeamSlug:     sa.TeamSlug,
-			Data: func(fields []*ServiceAccountTokenUpdatedActivityLogEntryDataUpdatedField) *ServiceAccountTokenUpdatedActivityLogEntryData {
-				if len(fields) == 0 {
-					return nil
-				}
-
-				return &ServiceAccountTokenUpdatedActivityLogEntryData{
-					UpdatedFields: fields,
-				}
-			}(updatedFields),
+			Data: &ServiceAccountTokenUpdatedActivityLogEntryData{
+				TokenName:     &t.Name,
+				UpdatedFields: updatedFields,
+			},
 		})
 	})
 	if err != nil {

--- a/internal/serviceaccount/queries.go
+++ b/internal/serviceaccount/queries.go
@@ -92,7 +92,7 @@ func Create(ctx context.Context, input CreateServiceAccountInput) (*ServiceAccou
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:       activitylog.ActivityLogEntryActionCreated,
 			Actor:        authz.ActorFromContext(ctx).User,
-			ResourceType: activityLogEntryResourceTypeServiceAccount,
+			ResourceType: ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName: sa.Name,
 			TeamSlug:     sa.TeamSlug,
 		})
@@ -137,7 +137,7 @@ func Update(ctx context.Context, input UpdateServiceAccountInput) (*ServiceAccou
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:       activitylog.ActivityLogEntryActionUpdated,
 			Actor:        authz.ActorFromContext(ctx).User,
-			ResourceType: activityLogEntryResourceTypeServiceAccount,
+			ResourceType: ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName: sa.Name,
 			TeamSlug:     sa.TeamSlug,
 			Data: func(fields []*ServiceAccountUpdatedActivityLogEntryDataUpdatedField) *ServiceAccountUpdatedActivityLogEntryData {
@@ -176,7 +176,7 @@ func Delete(ctx context.Context, input DeleteServiceAccountInput) error {
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:       activitylog.ActivityLogEntryActionDeleted,
 			Actor:        authz.ActorFromContext(ctx).User,
-			ResourceType: activityLogEntryResourceTypeServiceAccount,
+			ResourceType: ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName: existingSA.Name,
 			TeamSlug:     existingSA.TeamSlug,
 		})
@@ -226,7 +226,7 @@ func CreateToken(ctx context.Context, input CreateServiceAccountTokenInput) (*Se
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:       activityLogEntryActionCreateServiceAccountToken,
 			Actor:        authz.ActorFromContext(ctx).User,
-			ResourceType: activityLogEntryResourceTypeServiceAccount,
+			ResourceType: ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName: sa.Name,
 			TeamSlug:     sa.TeamSlug,
 			Data: &ServiceAccountTokenCreatedActivityLogEntryData{
@@ -287,7 +287,7 @@ func UpdateToken(ctx context.Context, input UpdateServiceAccountTokenInput) (*Se
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:       activityLogEntryActionUpdateServiceAccountToken,
 			Actor:        authz.ActorFromContext(ctx).User,
-			ResourceType: activityLogEntryResourceTypeServiceAccount,
+			ResourceType: ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName: sa.Name,
 			TeamSlug:     sa.TeamSlug,
 			Data: func(fields []*ServiceAccountTokenUpdatedActivityLogEntryDataUpdatedField) *ServiceAccountTokenUpdatedActivityLogEntryData {
@@ -331,7 +331,7 @@ func DeleteToken(ctx context.Context, input DeleteServiceAccountTokenInput) (*Se
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:       activityLogEntryActionDeleteServiceAccountToken,
 			Actor:        authz.ActorFromContext(ctx).User,
-			ResourceType: activityLogEntryResourceTypeServiceAccount,
+			ResourceType: ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName: sa.Name,
 			TeamSlug:     sa.TeamSlug,
 			Data: &ServiceAccountTokenDeletedActivityLogEntryData{
@@ -488,7 +488,7 @@ func AssignRole(ctx context.Context, input AssignRoleToServiceAccountInput) (*Se
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:       activityLogEntryActionAssignServiceAccountRole,
 			Actor:        authz.ActorFromContext(ctx).User,
-			ResourceType: activityLogEntryResourceTypeServiceAccount,
+			ResourceType: ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName: sa.Name,
 			TeamSlug:     sa.TeamSlug,
 			Data: &RoleAssignedToServiceAccountActivityLogEntryData{
@@ -538,7 +538,7 @@ func RevokeRole(ctx context.Context, input RevokeRoleFromServiceAccountInput) (*
 		return activitylog.Create(ctx, activitylog.CreateInput{
 			Action:       activityLogEntryActionRevokeServiceAccountRole,
 			Actor:        authz.ActorFromContext(ctx).User,
-			ResourceType: activityLogEntryResourceTypeServiceAccount,
+			ResourceType: ActivityLogEntryResourceTypeServiceAccount,
 			ResourceName: sa.Name,
 			TeamSlug:     sa.TeamSlug,
 			Data: &RoleRevokedFromServiceAccountActivityLogEntryData{

--- a/internal/workload/models.go
+++ b/internal/workload/models.go
@@ -1,6 +1,7 @@
 package workload
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"slices"
@@ -279,6 +280,58 @@ func TypeFromString(s string) (Type, error) {
 		return TypeJob, nil
 	default:
 		return -1, fmt.Errorf("unknown workload type: %s", s)
+	}
+}
+
+func (t Type) MarshalGQL(w io.Writer) {
+	value, err := t.gqlString()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Fprint(w, strconv.Quote(value))
+}
+
+func (t *Type) UnmarshalGQL(v any) error {
+	str, ok := v.(string)
+	if !ok {
+		return fmt.Errorf("WorkloadType must be a string")
+	}
+	switch str {
+	case "APPLICATION":
+		*t = TypeApplication
+	case "JOB":
+		*t = TypeJob
+	default:
+		return fmt.Errorf("%q is not a valid WorkloadType", str)
+	}
+	return nil
+}
+
+func (t Type) MarshalJSON() ([]byte, error) {
+	value, err := t.gqlString()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(value)
+}
+
+func (t *Type) UnmarshalJSON(data []byte) error {
+	var value string
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+	return t.UnmarshalGQL(value)
+}
+
+// gqlString returns the GraphQL enum string for the workload type.
+func (t Type) gqlString() (string, error) {
+	switch t {
+	case TypeApplication:
+		return "APPLICATION", nil
+	case TypeJob:
+		return "JOB", nil
+	default:
+		return "", fmt.Errorf("%d is not a valid WorkloadType", t)
 	}
 }
 


### PR DESCRIPTION
- Service accounts expose `activityLog`. They were the only major
  resource without one, so "who did what to this account" was
  unanswerable.
- Token update entries now include the name of the token that changed.
- Workload binding entries resolve the bound workload, so a caller can
  tell an application from a job and link to it.