### PR TITLE
fix: onprem har fått Aiven crd

### DIFF
--- a/charts/console-backend-rbac/templates/rbac.yaml
+++ b/charts/console-backend-rbac/templates/rbac.yaml
@@ -220,6 +220,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - aiven.io
+    resources:
+      - opensearches
+      - valkeys
+    verbs:
+      - list
+      - watch
+  - apiGroups:
       - ""
     resources:
       - users


### PR DESCRIPTION
Disse blir visst automatisk plukket opp av Nais API, så da må vi legge til leserettigheter.