### PR TITLE
fix(unleash): check revoked team in RevokeTeamAccess guard

### DIFF
--- a/internal/unleash/queries.go
+++ b/internal/unleash/queries.go
@@ -148,7 +148,7 @@ func RevokeTeamAccess(ctx context.Context, input RevokeTeamAccessToUnleashInput)
 		return nil, err
 	}
 
-	if !hasAccessToUnleash(input.TeamSlug, unleash) {
+	if !hasAccessToUnleash(input.RevokedTeamSlug, unleash) {
 		return unleash, nil
 	}
 


### PR DESCRIPTION
The early-return guard checked whether the owner team had access instead
of the team being revoked. With a stale or empty watcher cache this made
Remove Team Access silently do nothing.
