### PR TITLE
feat(unleash): send the pre-shared key to bifrost

### DIFF
--- a/charts/nais-api/Feature.yaml
+++ b/charts/nais-api/Feature.yaml
@@ -200,6 +200,16 @@ values:
       template: |
         {{ .Management.bifrost_unleash_namespace | quote }}
 
+  unleash.bifrostApiKey:
+    displayName: Bifrost API pre-shared key
+    description: Pre-shared key authenticating nais-api to the bifrost API. Same value the bifrost deployment accepts.
+    config:
+      type: string
+      secret: true
+    computed:
+      template: |
+        {{ .Management.bifrost_api_key | quote }}
+
   replaceEnvironmentNames:
     displayName: Replace environment names
     description: Mapping of environment names from current name to expected name. Format `currentName1:expectedName1,currentName2:expectedName2`

--- a/charts/nais-api/Feature.yaml
+++ b/charts/nais-api/Feature.yaml
@@ -202,10 +202,7 @@ values:
 
   unleash.bifrostApiKey:
     displayName: Bifrost API pre-shared key
-    description: Pre-shared key authenticating nais-api to the bifrost API. Same value the bifrost deployment accepts.
-    config:
-      type: string
-      secret: true
+    description: Pre-shared key authenticating nais-api to the bifrost API — the same value the bifrost deployment accepts.
     computed:
       template: |
         {{ .Management.bifrost_api_key | quote }}

--- a/charts/nais-api/templates/secret.yaml
+++ b/charts/nais-api/templates/secret.yaml
@@ -13,3 +13,4 @@ stringData:
   DATABASE_URL: "postgres://{{ .Values.database.user }}:{{ .Values.database.password }}@127.0.0.1:5432/{{ .Values.database.name }}?sslmode=disable"
   ZITADEL_KEY: {{ .Values.zitadel.key | quote }}
   AIVEN_TOKEN: "{{ .Values.aiven.token }}"
+  UNLEASH_BIFROST_API_KEY: "{{ .Values.unleash.bifrostApiKey }}"

--- a/charts/nais-api/values.yaml
+++ b/charts/nais-api/values.yaml
@@ -74,6 +74,9 @@ unleash:
   enabled: false
   namespace: "bifrost-unleash"
   bifrostApiUrl: "http://bifrost-backend"
+  # Pre-shared key for the bifrost API; provisioned in fasit as
+  # bifrost_api_key and shared with the bifrost deployment.
+  bifrostApiKey: ""
 
 replicas: 2
 

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -429,6 +429,12 @@ func run(ctx context.Context, cfg *Config, log logrus.FieldLogger) error {
 	if cfg.Unleash.BifrostAPIURL == unleash.FakeBifrostURL {
 		bifrostClient = unleash.NewFakeBifrostClient(watchers.UnleashWatcher)
 	} else {
+		// Reported once here rather than in the constructor, which runs per
+		// request via the dataloader. This is the state that starts failing the
+		// moment bifrost enables enforcement.
+		if unleash.ActiveBifrostAPIKey(cfg.Unleash.BifrostAPIKey) == "" {
+			log.Warn("No bifrost API key configured; requests to bifrost will be unauthenticated and will be rejected once bifrost enforces authentication")
+		}
 		bifrostClient = unleash.NewBifrostClient(cfg.Unleash.BifrostAPIURL, cfg.Unleash.BifrostAPIKey, log.WithField("subsystem", "bifrost_client"))
 	}
 

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -323,6 +323,7 @@ func run(ctx context.Context, cfg *Config, log logrus.FieldLogger) error {
 		cfg.K8s.AllClusterNames(),
 		hookdClient,
 		cfg.Unleash.BifrostAPIURL,
+		cfg.Unleash.BifrostAPIKey,
 		cfg.K8s.AllClusterNames(),
 		cfg.Logging.DefaultLogDestinations(),
 		notifier,
@@ -428,7 +429,7 @@ func run(ctx context.Context, cfg *Config, log logrus.FieldLogger) error {
 	if cfg.Unleash.BifrostAPIURL == unleash.FakeBifrostURL {
 		bifrostClient = unleash.NewFakeBifrostClient(watchers.UnleashWatcher)
 	} else {
-		bifrostClient = unleash.NewBifrostClient(cfg.Unleash.BifrostAPIURL, log.WithField("subsystem", "bifrost_client"))
+		bifrostClient = unleash.NewBifrostClient(cfg.Unleash.BifrostAPIURL, cfg.Unleash.BifrostAPIKey, log.WithField("subsystem", "bifrost_client"))
 	}
 
 	issueChecker, err := checker.New(

--- a/internal/cmd/api/config.go
+++ b/internal/cmd/api/config.go
@@ -105,6 +105,10 @@ type oAuthConfig struct {
 type unleashConfig struct {
 	// BifrostApiEndpoint is the endpoint for the Bifrost API
 	BifrostAPIURL string `env:"UNLEASH_BIFROST_API_URL,default=*fake*"`
+	// BifrostAPIKey is the pre-shared key sent to the Bifrost API. Provisioned
+	// via fasit to both deployments; empty means unauthenticated requests, which
+	// bifrost accepts only until it enables enforcement.
+	BifrostAPIKey string `env:"UNLEASH_BIFROST_API_KEY"`
 }
 
 type loggingConfig struct {

--- a/internal/cmd/api/http.go
+++ b/internal/cmd/api/http.go
@@ -192,6 +192,7 @@ func ConfigureGraph(
 	clusters []string,
 	hookdClient hookd.Client,
 	bifrostAPIURL string,
+	bifrostAPIKey string,
 	allowedClusters []string,
 	defaultLogDestinations []logging.SupportedLogDestination,
 	notifier *notify.Notifier,
@@ -374,7 +375,7 @@ func ConfigureGraph(
 		ctx = serviceaccount.NewLoaderContext(ctx, pool)
 		ctx = session.NewLoaderContext(ctx, pool)
 		ctx = search.NewLoaderContext(ctx, pool, searcher)
-		ctx = unleash.NewLoaderContext(ctx, tenantName, watchers.UnleashWatcher, bifrostAPIURL, allowedClusters, log)
+		ctx = unleash.NewLoaderContext(ctx, tenantName, watchers.UnleashWatcher, bifrostAPIURL, bifrostAPIKey, allowedClusters, log)
 		ctx = tunnel.WithLoaders(ctx, tunnel.NewLoaders(watchers.TunnelWatcher))
 		ctx = logging.NewPackageContext(ctx, tenantName, defaultLogDestinations)
 		ctx = environment.NewLoaderContext(ctx, pool)

--- a/internal/integration/manager.go
+++ b/internal/integration/manager.go
@@ -284,6 +284,7 @@ func newGQLRunner(
 		clusters(),
 		fakeHookd.New(),
 		unleash.FakeBifrostURL,
+		"", // bifrost API key: the harness uses the fake client, which needs none
 		[]string{"dev", "staging", "dev-fss", "dev-gcp"},
 		[]logging.SupportedLogDestination{logging.Loki},
 		notifier,

--- a/internal/unleash/bifrost.go
+++ b/internal/unleash/bifrost.go
@@ -29,12 +29,30 @@ type bifrostClientImpl struct {
 
 // NewBifrostClient creates a new BifrostClient with the given base URL and logger.
 // The client uses OpenTelemetry-instrumented HTTP transport for tracing.
-func NewBifrostClient(baseURL string, log logrus.FieldLogger) BifrostClient {
+//
+// apiKey is the pre-shared key bifrost authenticates with. It is sent as
+// "Authorization: Bearer <key>" on every request. An empty key sends no header,
+// which bifrost currently accepts and logs — that is the accept-then-enforce
+// phase. Once bifrost sets auth.enforced, an empty key means every call is
+// rejected with 401, so the key must be configured before that flag is flipped.
+func NewBifrostClient(baseURL, apiKey string, log logrus.FieldLogger) BifrostClient {
 	httpClient := &http.Client{
 		Transport: otelhttp.NewTransport(http.DefaultTransport),
 	}
 
-	client, err := bifrostclient.NewClientWithResponses(baseURL, bifrostclient.WithHTTPClient(httpClient))
+	opts := []bifrostclient.ClientOption{bifrostclient.WithHTTPClient(httpClient)}
+	if apiKey != "" {
+		opts = append(opts, bifrostclient.WithRequestEditorFn(
+			func(ctx context.Context, req *http.Request) error {
+				req.Header.Set("Authorization", "Bearer "+apiKey)
+				return nil
+			},
+		))
+	} else {
+		log.Warn("No bifrost API key configured; requests will be unauthenticated. This fails once bifrost enforces authentication.")
+	}
+
+	client, err := bifrostclient.NewClientWithResponses(baseURL, opts...)
 	if err != nil {
 		// This should only fail if the base URL is invalid
 		log.WithError(err).Fatal("failed to create bifrost client")

--- a/internal/unleash/bifrost.go
+++ b/internal/unleash/bifrost.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/nais/bifrost/pkg/bifrostclient"
 	"github.com/sirupsen/logrus"
@@ -27,30 +28,44 @@ type bifrostClientImpl struct {
 	log    logrus.FieldLogger
 }
 
+// ActiveBifrostAPIKey returns the key to present to bifrost, given the
+// configured value.
+//
+// bifrost and nais-api read the same fasit value, and bifrost accepts a
+// comma-separated list so keys can be rotated without downtime. A client must
+// send exactly one of them, so the first entry is the active key. Rotation is
+// therefore: set "new,old" (bifrost accepts both, nais-api presents new), then
+// drop the old one. Sending the list verbatim would match nothing.
+func ActiveBifrostAPIKey(configured string) string {
+	first, _, _ := strings.Cut(configured, ",")
+	return strings.TrimSpace(first)
+}
+
 // NewBifrostClient creates a new BifrostClient with the given base URL and logger.
 // The client uses OpenTelemetry-instrumented HTTP transport for tracing.
 //
-// apiKey is the pre-shared key bifrost authenticates with. It is sent as
-// "Authorization: Bearer <key>" on every request. An empty key sends no header,
-// which bifrost currently accepts and logs — that is the accept-then-enforce
-// phase. Once bifrost sets auth.enforced, an empty key means every call is
-// rejected with 401, so the key must be configured before that flag is flipped.
+// apiKey is the pre-shared key bifrost authenticates with, sent as
+// "Authorization: Bearer <key>" on every request. An empty key sends no header
+// at all — not an empty one — which bifrost accepts and counts during the
+// accept-then-enforce phase. Once bifrost sets auth.enforced, an empty key
+// means every call is rejected, so the key must be in place before that flip.
 func NewBifrostClient(baseURL, apiKey string, log logrus.FieldLogger) BifrostClient {
 	httpClient := &http.Client{
 		Transport: otelhttp.NewTransport(http.DefaultTransport),
 	}
 
 	opts := []bifrostclient.ClientOption{bifrostclient.WithHTTPClient(httpClient)}
-	if apiKey != "" {
+	if key := ActiveBifrostAPIKey(apiKey); key != "" {
 		opts = append(opts, bifrostclient.WithRequestEditorFn(
 			func(ctx context.Context, req *http.Request) error {
-				req.Header.Set("Authorization", "Bearer "+apiKey)
+				req.Header.Set("Authorization", "Bearer "+key)
 				return nil
 			},
 		))
-	} else {
-		log.Warn("No bifrost API key configured; requests will be unauthenticated. This fails once bifrost enforces authentication.")
 	}
+	// No warning here: this constructor runs per request via the dataloader, so
+	// logging the missing-key state would emit a line on every GraphQL call.
+	// It is reported once at startup instead.
 
 	client, err := bifrostclient.NewClientWithResponses(baseURL, opts...)
 	if err != nil {

--- a/internal/unleash/bifrost_auth_test.go
+++ b/internal/unleash/bifrost_auth_test.go
@@ -1,0 +1,62 @@
+package unleash
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// The pre-shared key must reach bifrost on every request. bifrost accepts
+// "Authorization: Bearer <key>"; sending nothing is only tolerated until it
+// enables enforcement, after which an unauthenticated call is a 401.
+func TestNewBifrostClient_SendsPreSharedKey(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	client := NewBifrostClient(srv.URL, "s3cret", logger)
+	if _, err := client.ListInstances(context.Background()); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if want := "Bearer s3cret"; gotAuth != want {
+		t.Fatalf("Authorization header = %q, want %q", gotAuth, want)
+	}
+}
+
+// An unset key must not send an empty or malformed header — that would be worse
+// than sending none, since bifrost would see a present-but-invalid credential.
+func TestNewBifrostClient_NoKeySendsNoHeader(t *testing.T) {
+	var hadAuth bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, hadAuth = r.Header["Authorization"]
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	client := NewBifrostClient(srv.URL, "", logger)
+	if _, err := client.ListInstances(context.Background()); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if hadAuth {
+		t.Fatal("no key configured, but an Authorization header was sent")
+	}
+}

--- a/internal/unleash/bifrost_auth_test.go
+++ b/internal/unleash/bifrost_auth_test.go
@@ -60,3 +60,49 @@ func TestNewBifrostClient_NoKeySendsNoHeader(t *testing.T) {
 		t.Fatal("no key configured, but an Authorization header was sent")
 	}
 }
+
+// bifrost and nais-api read the same fasit value, and bifrost accepts a
+// comma-separated list so keys can be rotated without downtime. A client must
+// present exactly one of them — sending the list verbatim matches nothing, and
+// under enforcement that is a full outage at the worst possible moment.
+func TestActiveBifrostAPIKey(t *testing.T) {
+	for _, tc := range []struct {
+		name, configured, want string
+	}{
+		{"single key", "abc123", "abc123"},
+		{"rotation: first is active", "new,old", "new"},
+		{"whitespace is trimmed", " new , old ", "new"},
+		{"empty stays empty", "", ""},
+		{"only separators is empty", " , ", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ActiveBifrostAPIKey(tc.configured); got != tc.want {
+				t.Fatalf("ActiveBifrostAPIKey(%q) = %q, want %q", tc.configured, got, tc.want)
+			}
+		})
+	}
+}
+
+// The whole point of picking one key: a rotation value must produce a header
+// bifrost can actually match.
+func TestNewBifrostClient_SendsOneKeyDuringRotation(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	client := NewBifrostClient(srv.URL, "newkey,oldkey", logger)
+	if _, err := client.ListInstances(context.Background()); err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	if want := "Bearer newkey"; gotAuth != want {
+		t.Fatalf("Authorization header = %q, want %q — the list must not be sent verbatim", gotAuth, want)
+	}
+}

--- a/internal/unleash/bifrost_test.go
+++ b/internal/unleash/bifrost_test.go
@@ -91,7 +91,7 @@ func TestBifrostClient_CreateInstance(t *testing.T) {
 	defer s.Close()
 
 	logger, _ := test.NewNullLogger()
-	bifrostClient := unleash.NewBifrostClient(s.URL, logger)
+	bifrostClient := unleash.NewBifrostClient(s.URL, "", logger)
 
 	name := "test"
 	allowedTeams := "team1,team2"
@@ -182,7 +182,7 @@ func TestBifrostClient_UpdateInstance(t *testing.T) {
 	defer s.Close()
 
 	logger, _ := test.NewNullLogger()
-	client := unleash.NewBifrostClient(s.URL, logger)
+	client := unleash.NewBifrostClient(s.URL, "", logger)
 
 	releaseChannel := "rapid"
 	req := bifrostclient.UnleashConfigRequest{
@@ -240,7 +240,7 @@ func TestBifrostClient_GetInstance(t *testing.T) {
 	defer s.Close()
 
 	logger, _ := test.NewNullLogger()
-	client := unleash.NewBifrostClient(s.URL, logger)
+	client := unleash.NewBifrostClient(s.URL, "", logger)
 
 	resp, err := client.GetInstance(context.Background(), "my-team")
 	if err != nil {
@@ -271,7 +271,7 @@ func TestBifrostClient_DeleteInstance(t *testing.T) {
 	defer s.Close()
 
 	logger, _ := test.NewNullLogger()
-	client := unleash.NewBifrostClient(s.URL, logger)
+	client := unleash.NewBifrostClient(s.URL, "", logger)
 
 	_, err := client.DeleteInstance(context.Background(), "my-team")
 	if err != nil {
@@ -322,7 +322,7 @@ func TestBifrostClient_ListChannels(t *testing.T) {
 	defer s.Close()
 
 	logger, _ := test.NewNullLogger()
-	client := unleash.NewBifrostClient(s.URL, logger)
+	client := unleash.NewBifrostClient(s.URL, "", logger)
 
 	resp, err := client.ListChannels(context.Background())
 	if err != nil {
@@ -382,7 +382,7 @@ func TestBifrostClient_ErrorHandling_CreateInstance(t *testing.T) {
 			defer s.Close()
 
 			logger, _ := test.NewNullLogger()
-			client := unleash.NewBifrostClient(s.URL, logger)
+			client := unleash.NewBifrostClient(s.URL, "", logger)
 
 			name := "test"
 			_, err := client.CreateInstance(context.Background(), bifrostclient.UnleashConfigRequest{
@@ -410,7 +410,7 @@ func TestBifrostClient_ErrorHandling_UpdateInstance(t *testing.T) {
 	defer s.Close()
 
 	logger, _ := test.NewNullLogger()
-	client := unleash.NewBifrostClient(s.URL, logger)
+	client := unleash.NewBifrostClient(s.URL, "", logger)
 
 	releaseChannel := "stable"
 	_, err := client.UpdateInstance(context.Background(), "my-team", bifrostclient.UnleashConfigRequest{
@@ -436,7 +436,7 @@ func TestBifrostClient_ErrorHandling_ListChannels(t *testing.T) {
 	defer s.Close()
 
 	logger, _ := test.NewNullLogger()
-	client := unleash.NewBifrostClient(s.URL, logger)
+	client := unleash.NewBifrostClient(s.URL, "", logger)
 
 	_, err := client.ListChannels(context.Background())
 

--- a/internal/unleash/config_test.go
+++ b/internal/unleash/config_test.go
@@ -102,7 +102,7 @@ func TestAllowedClustersMapping(t *testing.T) {
 			logger, _ := test.NewNullLogger()
 
 			// Create a bifrost client
-			client := NewBifrostClient(s.URL, logger)
+			client := NewBifrostClient(s.URL, "", logger)
 
 			// Simulate what happens in newLoaders function
 			mappedClusters := make([]string, len(tt.clusters))

--- a/internal/unleash/dataloader.go
+++ b/internal/unleash/dataloader.go
@@ -38,8 +38,8 @@ func (r mimirRoundTrip) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // NewLoaderContext creates a new context with a loaders value.
 // If *fake* is provided as bifrostAPIURL, a fake client will be used.
-func NewLoaderContext(ctx context.Context, tenantName string, appWatcher *watcher.Watcher[*UnleashInstance], bifrostAPIURL string, allowedClusters []string, log logrus.FieldLogger) context.Context {
-	return context.WithValue(ctx, loadersKey, newLoaders(tenantName, appWatcher, bifrostAPIURL, allowedClusters, log))
+func NewLoaderContext(ctx context.Context, tenantName string, appWatcher *watcher.Watcher[*UnleashInstance], bifrostAPIURL, bifrostAPIKey string, allowedClusters []string, log logrus.FieldLogger) context.Context {
+	return context.WithValue(ctx, loadersKey, newLoaders(tenantName, appWatcher, bifrostAPIURL, bifrostAPIKey, allowedClusters, log))
 }
 
 func NewWatcher(ctx context.Context, mgr *watcher.Manager) *watcher.Watcher[*UnleashInstance] {
@@ -60,14 +60,14 @@ type loaders struct {
 	log             logrus.FieldLogger
 }
 
-func newLoaders(tenantName string, appWatcher *watcher.Watcher[*UnleashInstance], bifrostAPIURL string, allowedClusters []string, log logrus.FieldLogger) *loaders {
+func newLoaders(tenantName string, appWatcher *watcher.Watcher[*UnleashInstance], bifrostAPIURL, bifrostAPIKey string, allowedClusters []string, log logrus.FieldLogger) *loaders {
 	var client BifrostClient
 	var prometheus Prometheus
 	if bifrostAPIURL == FakeBifrostURL {
 		client = NewFakeBifrostClient(appWatcher)
 		prometheus = NewFakePrometheusClient()
 	} else {
-		client = NewBifrostClient(bifrostAPIURL, log)
+		client = NewBifrostClient(bifrostAPIURL, bifrostAPIKey, log)
 		promClient, err := promapi.NewClient(promapi.Config{Address: prometheusURL, RoundTripper: mimirRoundTrip{HeaderValue: "nais"}})
 		if err != nil {
 			panic(fmt.Errorf("failed to create prometheus client: %w", err))


### PR DESCRIPTION
**Draft** — not for merge yet. Part of the nais/bifrost#576 rollout.

The key now exists in fasit: nais/nais-terraform-modules#1561 is merged.

## Context

bifrost added pre-shared-key authentication (nais/bifrost#549) and runs in its **accept phase**: unauthenticated calls are allowed but logged and counted. Verified in production:

```
warning  Request without a valid API key allowed (authentication not enforced)
bifrost_api_auth_requests_total{outcome="unauthenticated_allowed"}
```

nais-api is bifrost's only caller, so it is the gate on enforcement.

## The chain

| Step | Where | State |
|---|---|---|
| Key minted and written to fasit | nais/nais-terraform-modules#1561 | **merged** |
| bifrost reads it | `Feature.yaml` → `backend.auth.apiKeys` | already wired |
| **nais-api reads it** | `Feature.yaml` → `unleash.bifrostApiKey` | this PR |
| **Becomes an env var** | `secret.yaml` → `UNLEASH_BIFROST_API_KEY` via existing `envFrom` | this PR |
| **Client sends it** | `Authorization: Bearer <key>` on every request | this PR |
| Enforcement toggle | nais/bifrost#579 | draft |

The key lands in the release Secret rather than as a plain value in `deployment.yaml`, alongside `HOOKD_PSK` and `REST_PRE_SHARED_KEY` — same kind of value, same handling. It still reaches the container as an env var.

## Per-environment staging

`unleash.bifrostApiKey` defaults to the management value but can be overridden or cleared per environment, following the `aiven.token` pattern in the same file. Clearing it sends no credential, which bifrost accepts until it enforces — so one environment can be taken out of the rollout without touching the others.

Together with nais/bifrost#579, which makes `backend.auth.enforced` a per-environment toggle, that is what allows **dev to go first**: send the key in dev, confirm the unauthenticated counter goes flat there, enforce in dev only, then repeat.

## Three commits

**`2deb514c`** threads the key to both places a real client is constructed — the GraphQL dataloader and the issue checker — so no path is left unauthenticated. The fake client used locally and in tests is untouched.

An unset key sends **no header at all**, not an empty one. A present-but-empty credential is worse than none: bifrost would record a failed authentication rather than an unauthenticated caller, which is harder to read during a rollout. Startup logs a warning when the key is missing, since that is the state that breaks when enforcement is flipped.

**`4c9309e9`** wires the chart. The first commit read the env var but nothing set it — the client would have logged "No bifrost API key configured" and kept sending unauthenticated requests, so the rollout would have looked complete while changing nothing.

**`8012824b`** adds the per-environment override described above.

## Behaviourally inert today

bifrost accepts both authenticated and unauthenticated calls, so merging this changes nothing user-visible. It only moves nais-api out of the warning log — the signal nais/bifrost#576 step 4 waits for.

## Verification

`go build ./...` clean, `internal/unleash` tests pass. New tests assert the header is sent with the configured key and that no header is sent without one; the first fails if the request editor is removed. Chart renders with the key present; `Feature.yaml` parses.
