### PR TITLE
fix: kun tell teams som fortsatt eksisterer

### DIFF
--- a/internal/unleash/models.go
+++ b/internal/unleash/models.go
@@ -180,7 +180,12 @@ func (i *DeleteUnleashInstanceInput) Validate(ctx context.Context) error {
 		return verr.NilIfEmpty()
 	}
 
-	if len(instance.AllowedTeamSlugs) > 1 {
+	existing, err := team.ListBySlugs(ctx, instance.AllowedTeamSlugs, nil)
+	if err != nil {
+		return err
+	}
+
+	if existing.PageInfo.TotalCount > 1 {
 		verr.Add("unleash", "Revoke access for all other teams before deleting the unleash instance.")
 	}
 


### PR DESCRIPTION
Når vi lister opp teams for Unleash viser vi kun teams som fortsatt eksisterer. Når man skal slette en Unleashinstans så teller vi med alle teams. Tenker det fornuftige er å bare ignorere teams som ikke eksisterer lengre.