### PR TITLE
Field validation strict for apply

### DIFF
--- a/internal/apply/client.go
+++ b/internal/apply/client.go
@@ -68,8 +68,9 @@ func ApplyResource(
 		types.ApplyPatchType,
 		data,
 		metav1.PatchOptions{
-			FieldManager: fieldManager,
-			Force:        new(true),
+			FieldManager:    fieldManager,
+			Force:           new(true),
+			FieldValidation: metav1.FieldValidationStrict,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
This gives an error if a user tries to use a field not defined
